### PR TITLE
fix: move useEffect before conditional return in Layout to comply with React hooks rules

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -37,10 +37,6 @@ export default function Layout() {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [studentModalOpen]);
 
-  if (!isAuthenticated) {
-    return <Outlet />;
-  }
-
   useEffect(() => {
     if (!studentModalOpen) return;
     if (!username) return;
@@ -68,6 +64,10 @@ export default function Layout() {
       cancelled = true;
     };
   }, [studentModalOpen, username]);
+
+  if (!isAuthenticated) {
+    return <Outlet />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-100 via-indigo-50/60 to-sky-100/60">


### PR DESCRIPTION
## Changes
- Moved the `useEffect` (student profile loader) before the conditional `if (!isAuthenticated) return <Outlet />` early return in `Layout.tsx`

## Purpose
The `useEffect` was placed after a conditional early return, violating React's Rules of Hooks. Hooks must always be called in the same order on every render and cannot appear after an early return.

## Test Result
- App loads correctly when logged in (student modal still works)
- App loads correctly when logged out (unauthenticated route still renders)
- No console warnings about hooks order

## Related Issue
Fixes #92

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Docs
- [ ] Test

## Checklist
- [x] Code builds locally
- [x] No new warnings/errors
- [x] PR ready for review