### PR TITLE
Bug: useEffect called after conditional return in Layout.tsx violates React hooks rules

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -37,10 +37,6 @@ export default function Layout() {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [studentModalOpen]);
 
-  if (!isAuthenticated) {
-    return <Outlet />;
-  }
-
   useEffect(() => {
     if (!studentModalOpen) return;
     if (!username) return;
@@ -68,6 +64,10 @@ export default function Layout() {
       cancelled = true;
     };
   }, [studentModalOpen, username]);
+
+  if (!isAuthenticated) {
+    return <Outlet />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-100 via-indigo-50/60 to-sky-100/60">


### PR DESCRIPTION
## Changes
- Moved the student profile useEffect above the unauthenticated early return.
- Left the existing guards inside the effect (if (!studentModalOpen) return;, if (!username) return;) so behavior is unchanged when logged out or when the modal is closed.

## Purpose
- All hooks in Layout run unconditionally at the top level before any conditional return.
- No full-page behavior change intended; only hook ordering / compliance fix.

## Test Result
- npm run build (frontend) passes.
- Smoke: open app while logged out → no hook-order warnings; log in → open Student Center → profile still loads as before.

## Related Issue
Fixes #92  

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Docs
- [ ] Test

## Checklist
- [x] Code builds locally
- [x] No new warnings/errors
- [x] PR ready for review