### PR TITLE
Bug: User registration fails and new accounts cannot be created

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,8 @@
 import os
 
+from dotenv import load_dotenv
+load_dotenv()
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,5 +5,6 @@ pydantic[email]
 python-jose[cryptography]
 bcrypt
 python-multipart
+python-dotenv
 pytest
 httpx

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -28,7 +28,8 @@ api.interceptors.request.use((config) => {
 api.interceptors.response.use(
   (res) => res,
   (error) => {
-    if (error.response?.status === 401) {
+    const isLoginRequest = error.config?.url?.includes('/auth/login');
+    if (error.response?.status === 401 && !isLoginRequest) {
       localStorage.removeItem('token');
       window.location.href = `${import.meta.env.BASE_URL}login`;
     }


### PR DESCRIPTION
## Changes
- Added python-dotenv to requirements.txt and called load_dotenv() in main.py to load JWT_SECRET from backend/.env at startup
- Created backend/.env with a generated JWT_SECRET value (already excluded from version control via .gitignore)
- Fixed the 401 response interceptor in api.ts to skip the page redirect when the failing request is the login endpoint itself

## Purpose
Previously the backend crashed silently on startup because JWT_SECRET was read via os.environ["JWT_SECRET"] but no .env file existed and python-dotenv was never loaded, making all API calls fail. Additionally, even if the backend were running, a wrong-password login attempt would trigger a full page reload instead of showing an error message, because the Axios 401 interceptor fired on the login request itself.

## Test Result
- Registered a new account and verified it completes successfully
- Attempted login with incorrect credentials and confirmed the error message now displays instead of a blank page reload
- Attempted login with correct credentials and confirmed successful redirect to dashboard

## Related Issue
Fixes #103 

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Docs
- [ ] Test

## Checklist
- [x] Code builds locally
- [x] No new warnings/errors
- [x] PR ready for review