### PR TITLE
fix: use Alert component for error display in OralPracticePage

### DIFF
--- a/frontend/src/pages/OralPracticePage.tsx
+++ b/frontend/src/pages/OralPracticePage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Alert } from '../components/Alert';
 
 type Difficulty = 'easy' | 'medium' | 'hard';
 type Category = 'cs' | 'mechanical' | 'civil' | 'transportation' | 'math';
@@ -829,7 +830,7 @@ export default function OralPracticePage() {
                 Back to difficulty
               </button>
             </div>
-            {error && <p className="text-sm text-red-500 mt-2">{error}</p>}
+            {error && <Alert variant="error">{error}</Alert>}
             {audioUrl && (
               <div className="mt-4 space-y-1">
                 <p className="text-sm text-gray-600">Your recording:</p>


### PR DESCRIPTION
## Changes
- Imported the shared Alert component into OralPracticePage.tsx
- Replaced the plain p element with Alert variant error for microphone error display

## Purpose
The error message for microphone access failure was using a plain p tag, while all other pages use the shared Alert component. This caused inconsistent error styling.

## Test Result
- Error displays with the styled Alert box when microphone permission is denied
- Error styling matches other pages (QuizPage, ListeningPage, etc.)

## Related Issue
Fixes #94

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Docs
- [ ] Test

## Checklist
- [x] Code builds locally
- [x] No new warnings/errors
- [x] PR ready for review