### PR TITLE
fix(ReviewPage): resolve merge conflict residue causing compilation f…

### DIFF
--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1,7 +1,3 @@
- ZeyuXu/frontend
-import { useCallback, useEffect, useState } from 'react';
-
-import { useEffect, useRef, useState } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getReviewWords, submitReview } from '../services/api';
 import { Alert } from '../components/Alert';
@@ -43,21 +39,6 @@ export default function ReviewPage() {
       setWords(res.data);
       if (res.data.length === 0) setFinished(true);
     } catch {
-      setWords([]);
-      setFinished(true);
-    } finally {
-      setLoading(false);
-    }
-  useEffect(() => {
-    getReviewWords(10)
-      .then((res) => {
-        setWords(res.data);
-        if (res.data.length === 0) setFinished(true);
-      })
-      .catch(() => {
-        setLoadError('Failed to load review words. Please check your connection and try again.');
-      })
-      .finally(() => setLoading(false));
       setLoadError('Failed to load review words. Please check your connection and try again.');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Changes
- Remove branch name and duplicate `import` lines left from merge conflict in `ReviewPage.tsx`
- Remove stale `useEffect` block nested inside `loadSession` callback
- Fix `catch` block to call `setLoadError(...)` for proper error UI display

## Purpose
The `ZeyuXu/frontend` branch merge left conflict residue in `ReviewPage.tsx`, causing Vite to throw `Identifier 'useEffect' has already been declared` and making the Review page completely unusable.

## Test Result
- Frontend compiles without errors after the fix
- Review page loads and functions correctly (flashcard flip, answer submission, session complete screen)

## Related Issue
Fixes #111 

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Docs
- [ ] Test

## Checklist
- [x] Code builds locally
- [x] No new warnings/errors
- [x] PR ready for review