### PR TITLE
feat(quiz): add multi-language support for quiz interface

### DIFF
--- a/backend/app/routers/quiz.py
+++ b/backend/app/routers/quiz.py
@@ -49,17 +49,25 @@ def generate_quiz(
 
     questions_out: list[QuizQuestionResponse] = []
 
+    reverse = req.quiz_type == "cn_to_en"
+
     for word in selected_words:
-        # Build 4 options: 1 correct + 3 distractors
         distractors = [w for w in all_words if w.id != word.id]
         distractor_words = random.sample(distractors, min(3, len(distractors)))
-        options = [word.chinese] + [d.chinese for d in distractor_words]
+
+        if reverse:
+            options = [word.english] + [d.english for d in distractor_words]
+            correct = word.english
+        else:
+            options = [word.chinese] + [d.chinese for d in distractor_words]
+            correct = word.chinese
+
         random.shuffle(options)
 
         qq = QuizQuestion(
             quiz_id=quiz.id,
             word_id=word.id,
-            correct_answer=word.chinese,
+            correct_answer=correct,
         )
         db.add(qq)
         db.flush()
@@ -69,8 +77,9 @@ def generate_quiz(
                 id=qq.id,
                 word_id=word.id,
                 english=word.english,
+                chinese=word.chinese,
                 options=options,
-                correct_answer=None,  # Don't reveal answer on generation
+                correct_answer=None,
             )
         )
 

--- a/backend/app/schemas/quiz.py
+++ b/backend/app/schemas/quiz.py
@@ -22,6 +22,7 @@ class QuizQuestionResponse(BaseModel):
     id: int
     word_id: int
     english: str
+    chinese: str = ""
     options: list[str]
     correct_answer: str | None = None
 

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -4,6 +4,7 @@ import type { Quiz, QuizSubmitResult } from '../types';
 import { Alert } from '../components/Alert';
 
 type Phase = 'setup' | 'playing' | 'result';
+type QuizMode = 'en_to_cn' | 'cn_to_en';
 
 /** Matches `category` in seed.py — English short labels only. */
 const QUIZ_CATEGORY_ORDER = [
@@ -44,6 +45,10 @@ export default function QuizPage() {
   const [currentQ, setCurrentQ] = useState(0);
   const [answers, setAnswers] = useState<Record<number, string>>({});
   const [result, setResult] = useState<QuizSubmitResult | null>(null);
+  const [quizMode, setQuizMode] = useState<QuizMode>(() => {
+    const saved = localStorage.getItem('quiz_mode');
+    return saved === 'cn_to_en' ? 'cn_to_en' : 'en_to_cn';
+  });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -53,6 +58,11 @@ export default function QuizPage() {
 
   const sortedCategories = useMemo(() => sortQuizCategories(categories), [categories]);
 
+  const handleModeChange = (mode: QuizMode) => {
+    setQuizMode(mode);
+    localStorage.setItem('quiz_mode', mode);
+  };
+
   const startQuiz = async () => {
     setLoading(true);
     setError('');
@@ -60,6 +70,7 @@ export default function QuizPage() {
       const req = {
         category: selectedCategory || undefined,
         count: questionCount,
+        quiz_type: quizMode === 'cn_to_en' ? 'cn_to_en' : 'multiple_choice',
         difficulty: selectedDifficulty || undefined,
       };
       const res = await generateQuiz(req);
@@ -164,6 +175,34 @@ export default function QuizPage() {
           </div>
 
           <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Quiz Mode</label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => handleModeChange('en_to_cn')}
+                className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium border-2 transition cursor-pointer ${
+                  quizMode === 'en_to_cn'
+                    ? 'border-indigo-600 bg-indigo-50 text-indigo-700'
+                    : 'border-gray-200 text-gray-600 hover:border-gray-300'
+                }`}
+              >
+                English → Chinese
+              </button>
+              <button
+                type="button"
+                onClick={() => handleModeChange('cn_to_en')}
+                className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium border-2 transition cursor-pointer ${
+                  quizMode === 'cn_to_en'
+                    ? 'border-indigo-600 bg-indigo-50 text-indigo-700'
+                    : 'border-gray-200 text-gray-600 hover:border-gray-300'
+                }`}
+              >
+                Chinese → English
+              </button>
+            </div>
+          </div>
+
+          <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
               Number of Questions: {questionCount}
             </label>
@@ -217,8 +256,12 @@ export default function QuizPage() {
 
         {/* Question card */}
         <div className="part-box p-6">
-          <p className="text-sm text-gray-400 mb-2">What does this word mean?</p>
-          <h2 className="text-3xl font-bold text-gray-900 mb-6">{question.english}</h2>
+          <p className="text-sm text-gray-400 mb-2">
+            {quizMode === 'cn_to_en' ? 'What is the English translation?' : 'What does this word mean?'}
+          </p>
+          <h2 className="text-3xl font-bold text-gray-900 mb-6">
+            {quizMode === 'cn_to_en' ? question.chinese : question.english}
+          </h2>
 
           <div className="grid grid-cols-1 gap-3">
             {question.options.map((option) => (
@@ -302,7 +345,12 @@ export default function QuizPage() {
                       {r.is_correct ? 'Correct' : 'Incorrect'}
                     </span>
                     {question && (
-                      <p className="text-lg font-bold text-gray-900 mt-1">{question.english}</p>
+                      <p className="text-lg font-bold text-gray-900 mt-1">
+                        {quizMode === 'cn_to_en' ? question.chinese : question.english}
+                        <span className="text-sm font-normal text-gray-500 ml-2">
+                          ({quizMode === 'cn_to_en' ? question.english : question.chinese})
+                        </span>
+                      </p>
                     )}
                     <p className="font-medium text-gray-900 mt-1">Your answer: {r.user_answer || '(no answer)'}</p>
                     {!r.is_correct && (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -43,6 +43,7 @@ export interface QuizQuestion {
   id: number;
   word_id: number;
   english: string;
+  chinese: string;
   options: string[];
   correct_answer: string | null;
 }


### PR DESCRIPTION
## Changes
- Added quiz mode toggle (English to Chinese / Chinese to English) on the quiz setup page
- Backend supports reverse quiz mode via quiz_type cn_to_en: shows Chinese word with English options
- Added chinese field to QuizQuestionResponse schema and frontend QuizQuestion type
- Result cards now show both English and Chinese words for easier review
- User language preference is stored in localStorage and persists across sessions

## Purpose
Currently the quiz only supports one direction (English word to Chinese translation). Adding reverse mode lets students practice both directions, improving bilingual learning effectiveness and making the app more accessible to students at different proficiency levels.

## Test Result
- EN to CN mode works as before: shows English word, pick Chinese translation
- CN to EN mode correctly shows Chinese word with English options
- Mode preference persists after page refresh via localStorage
- Result cards display both languages regardless of mode

## Related Issue
Fixes #113

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Docs
- [ ] Test

## Checklist
- [x] Code builds locally
- [x] No new warnings/errors
- [x] PR ready for review