### PR TITLE
feat(quiz): expand multi-language support with French, Spanish, Arabic, and Persian

### DIFF
--- a/backend/app/models/word.py
+++ b/backend/app/models/word.py
@@ -10,6 +10,10 @@ class Word(Base):
     id = Column(Integer, primary_key=True, index=True)
     english = Column(String(100), nullable=False, index=True)
     chinese = Column(String(100), nullable=False)
+    french = Column(String(100), nullable=True, default="")
+    spanish = Column(String(100), nullable=True, default="")
+    arabic = Column(String(100), nullable=True, default="")
+    persian = Column(String(100), nullable=True, default="")
     part_of_speech = Column(String(20), nullable=False)
     example_sentence = Column(String(500), nullable=True)
     difficulty_level = Column(Integer, nullable=False, default=1)  # 1=easy, 2=medium, 3=hard

--- a/backend/app/routers/quiz.py
+++ b/backend/app/routers/quiz.py
@@ -20,21 +20,37 @@ from app.services.auth import get_current_user
 router = APIRouter(prefix="/api/quiz", tags=["quiz"])
 
 
+SUPPORTED_LANGUAGES = {"chinese", "french", "spanish", "arabic", "persian"}
+
+
+def _get_lang_value(word: Word, lang: str) -> str:
+    return getattr(word, lang, "") or ""
+
+
 @router.post("/generate", response_model=QuizResponse)
 def generate_quiz(
     req: QuizGenerateRequest,
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
+    lang = req.target_language if req.target_language in SUPPORTED_LANGUAGES else "chinese"
+
     query = db.query(Word)
     if req.category:
         query = query.filter(Word.category == req.category)
     if req.difficulty:
         query = query.filter(Word.difficulty_level == req.difficulty)
 
+    if lang != "chinese":
+        lang_col = getattr(Word, lang)
+        query = query.filter(lang_col.isnot(None), lang_col != "")
+
     all_words = query.all()
     if len(all_words) < 4:
-        raise HTTPException(status_code=400, detail="Not enough words to generate a quiz")
+        raise HTTPException(
+            status_code=400,
+            detail="Not enough words with translations in the selected language",
+        )
 
     count = min(req.count, len(all_words))
     selected_words = random.sample(all_words, count)
@@ -48,7 +64,6 @@ def generate_quiz(
     db.flush()
 
     questions_out: list[QuizQuestionResponse] = []
-
     reverse = req.quiz_type == "cn_to_en"
 
     for word in selected_words:
@@ -59,8 +74,10 @@ def generate_quiz(
             options = [word.english] + [d.english for d in distractor_words]
             correct = word.english
         else:
-            options = [word.chinese] + [d.chinese for d in distractor_words]
-            correct = word.chinese
+            options = [_get_lang_value(word, lang)] + [
+                _get_lang_value(d, lang) for d in distractor_words
+            ]
+            correct = _get_lang_value(word, lang)
 
         random.shuffle(options)
 
@@ -78,6 +95,10 @@ def generate_quiz(
                 word_id=word.id,
                 english=word.english,
                 chinese=word.chinese,
+                french=_get_lang_value(word, "french"),
+                spanish=_get_lang_value(word, "spanish"),
+                arabic=_get_lang_value(word, "arabic"),
+                persian=_get_lang_value(word, "persian"),
                 options=options,
                 correct_answer=None,
             )

--- a/backend/app/schemas/quiz.py
+++ b/backend/app/schemas/quiz.py
@@ -7,6 +7,7 @@ class QuizGenerateRequest(BaseModel):
     count: int = 10
     quiz_type: str = "multiple_choice"
     difficulty: int | None = None
+    target_language: str = "chinese"
 
 
 class QuizAnswerItem(BaseModel):
@@ -23,6 +24,10 @@ class QuizQuestionResponse(BaseModel):
     word_id: int
     english: str
     chinese: str = ""
+    french: str = ""
+    spanish: str = ""
+    arabic: str = ""
+    persian: str = ""
     options: list[str]
     correct_answer: str | None = None
 

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -47,10 +47,98 @@ def _ex(english: str, cat: str) -> str:
     return f"In first-year {cat.replace('_', ' ')} courses, students meet '{english}' ({m})."
 
 
+MULTI_LANG: dict[str, dict[str, str]] = {
+    "algorithm": {"french": "algorithme", "spanish": "algoritmo", "arabic": "خوارزمية", "persian": "الگوریتم"},
+    "variable": {"french": "variable", "spanish": "variable", "arabic": "متغير", "persian": "متغیر"},
+    "function": {"french": "fonction", "spanish": "función", "arabic": "دالة", "persian": "تابع"},
+    "loop": {"french": "boucle", "spanish": "bucle", "arabic": "حلقة", "persian": "حلقه"},
+    "array": {"french": "tableau", "spanish": "arreglo", "arabic": "مصفوفة", "persian": "آرایه"},
+    "string": {"french": "chaîne", "spanish": "cadena", "arabic": "سلسلة نصية", "persian": "رشته"},
+    "integer": {"french": "entier", "spanish": "entero", "arabic": "عدد صحيح", "persian": "عدد صحیح"},
+    "boolean": {"french": "booléen", "spanish": "booleano", "arabic": "منطقي", "persian": "بولی"},
+    "syntax": {"french": "syntaxe", "spanish": "sintaxis", "arabic": "صياغة", "persian": "نحو"},
+    "compile": {"french": "compiler", "spanish": "compilar", "arabic": "ترجمة", "persian": "کامپایل"},
+    "database": {"french": "base de données", "spanish": "base de datos", "arabic": "قاعدة بيانات", "persian": "پایگاه داده"},
+    "memory": {"french": "mémoire", "spanish": "memoria", "arabic": "ذاكرة", "persian": "حافظه"},
+    "processor": {"french": "processeur", "spanish": "procesador", "arabic": "معالج", "persian": "پردازنده"},
+    "thread": {"french": "fil d'exécution", "spanish": "hilo", "arabic": "خيط", "persian": "رشته اجرا"},
+    "encryption": {"french": "chiffrement", "spanish": "cifrado", "arabic": "تشفير", "persian": "رمزنگاری"},
+    "recursion": {"french": "récursion", "spanish": "recursión", "arabic": "تكرار ذاتي", "persian": "بازگشت"},
+    "stack": {"french": "pile", "spanish": "pila", "arabic": "مكدس", "persian": "پشته"},
+    "queue": {"french": "file d'attente", "spanish": "cola", "arabic": "طابور", "persian": "صف"},
+    "pointer": {"french": "pointeur", "spanish": "puntero", "arabic": "مؤشر", "persian": "اشاره‌گر"},
+    "debug": {"french": "débogage", "spanish": "depurar", "arabic": "تصحيح الأخطاء", "persian": "اشکال‌زدایی"},
+    "torque": {"french": "couple", "spanish": "par de torsión", "arabic": "عزم الدوران", "persian": "گشتاور"},
+    "friction": {"french": "frottement", "spanish": "fricción", "arabic": "احتكاك", "persian": "اصطکاک"},
+    "gear": {"french": "engrenage", "spanish": "engranaje", "arabic": "ترس", "persian": "چرخ‌دنده"},
+    "bearing": {"french": "roulement", "spanish": "rodamiento", "arabic": "محمل", "persian": "بلبرینگ"},
+    "shaft": {"french": "arbre", "spanish": "eje", "arabic": "عمود دوران", "persian": "شافت"},
+    "piston": {"french": "piston", "spanish": "pistón", "arabic": "مكبس", "persian": "پیستون"},
+    "turbine": {"french": "turbine", "spanish": "turbina", "arabic": "توربين", "persian": "توربین"},
+    "welding": {"french": "soudage", "spanish": "soldadura", "arabic": "لحام", "persian": "جوشکاری"},
+    "alloy": {"french": "alliage", "spanish": "aleación", "arabic": "سبيكة", "persian": "آلیاژ"},
+    "stress": {"french": "contrainte", "spanish": "esfuerzo", "arabic": "إجهاد", "persian": "تنش"},
+    "strain": {"french": "déformation", "spanish": "deformación", "arabic": "انفعال", "persian": "کرنش"},
+    "elasticity": {"french": "élasticité", "spanish": "elasticidad", "arabic": "مرونة", "persian": "کشسانی"},
+    "viscosity": {"french": "viscosité", "spanish": "viscosidad", "arabic": "لزوجة", "persian": "گرانروی"},
+    "hydraulic": {"french": "hydraulique", "spanish": "hidráulico", "arabic": "هيدروليكي", "persian": "هیدرولیک"},
+    "thermodynamics": {"french": "thermodynamique", "spanish": "termodinámica", "arabic": "ديناميكا حرارية", "persian": "ترمودینامیک"},
+    "concrete": {"french": "béton", "spanish": "concreto", "arabic": "خرسانة", "persian": "بتن"},
+    "foundation": {"french": "fondation", "spanish": "cimentación", "arabic": "أساس", "persian": "پی"},
+    "beam": {"french": "poutre", "spanish": "viga", "arabic": "عارضة", "persian": "تیر"},
+    "column": {"french": "colonne", "spanish": "columna", "arabic": "عمود", "persian": "ستون"},
+    "bridge": {"french": "pont", "spanish": "puente", "arabic": "جسر", "persian": "پل"},
+    "dam": {"french": "barrage", "spanish": "presa", "arabic": "سد", "persian": "سد"},
+    "drainage": {"french": "drainage", "spanish": "drenaje", "arabic": "صرف", "persian": "زهکشی"},
+    "reinforcement": {"french": "armature", "spanish": "refuerzo", "arabic": "تسليح", "persian": "آرماتور"},
+    "soil": {"french": "sol", "spanish": "suelo", "arabic": "تربة", "persian": "خاک"},
+    "load": {"french": "charge", "spanish": "carga", "arabic": "حمل", "persian": "بار"},
+    "cement": {"french": "ciment", "spanish": "cemento", "arabic": "أسمنت", "persian": "سیمان"},
+    "steel": {"french": "acier", "spanish": "acero", "arabic": "فولاذ", "persian": "فولاد"},
+    "survey": {"french": "levé topographique", "spanish": "levantamiento", "arabic": "مسح", "persian": "نقشه‌برداری"},
+    "seismic": {"french": "sismique", "spanish": "sísmico", "arabic": "زلزالي", "persian": "لرزه‌ای"},
+    "excavation": {"french": "excavation", "spanish": "excavación", "arabic": "حفر", "persian": "خاکبرداری"},
+    "traffic": {"french": "circulation", "spanish": "tráfico", "arabic": "حركة المرور", "persian": "ترافیک"},
+    "highway": {"french": "autoroute", "spanish": "autopista", "arabic": "طريق سريع", "persian": "بزرگراه"},
+    "intersection": {"french": "intersection", "spanish": "intersección", "arabic": "تقاطع", "persian": "تقاطع"},
+    "signal": {"french": "signal", "spanish": "señal", "arabic": "إشارة", "persian": "سیگنال"},
+    "pavement": {"french": "chaussée", "spanish": "pavimento", "arabic": "رصيف", "persian": "روسازی"},
+    "vehicle": {"french": "véhicule", "spanish": "vehículo", "arabic": "مركبة", "persian": "خودرو"},
+    "lane": {"french": "voie", "spanish": "carril", "arabic": "حارة", "persian": "خط"},
+    "speed": {"french": "vitesse", "spanish": "velocidad", "arabic": "سرعة", "persian": "سرعت"},
+    "brake": {"french": "frein", "spanish": "freno", "arabic": "فرامل", "persian": "ترمز"},
+    "engine": {"french": "moteur", "spanish": "motor", "arabic": "محرك", "persian": "موتور"},
+    "suspension": {"french": "suspension", "spanish": "suspensión", "arabic": "تعليق", "persian": "فنربندی"},
+    "navigation": {"french": "navigation", "spanish": "navegación", "arabic": "ملاحة", "persian": "ناوبری"},
+    "logistics": {"french": "logistique", "spanish": "logística", "arabic": "لوجستيات", "persian": "تدارکات"},
+    "congestion": {"french": "congestion", "spanish": "congestión", "arabic": "ازدحام", "persian": "تراکم"},
+    "equation": {"french": "équation", "spanish": "ecuación", "arabic": "معادلة", "persian": "معادله"},
+    "matrix": {"french": "matrice", "spanish": "matriz", "arabic": "مصفوفة", "persian": "ماتریس"},
+    "vector": {"french": "vecteur", "spanish": "vector", "arabic": "متجه", "persian": "بردار"},
+    "integral": {"french": "intégrale", "spanish": "integral", "arabic": "تكامل", "persian": "انتگرال"},
+    "derivative": {"french": "dérivée", "spanish": "derivada", "arabic": "مشتقة", "persian": "مشتق"},
+    "probability": {"french": "probabilité", "spanish": "probabilidad", "arabic": "احتمال", "persian": "احتمال"},
+    "theorem": {"french": "théorème", "spanish": "teorema", "arabic": "نظرية", "persian": "قضیه"},
+    "geometry": {"french": "géométrie", "spanish": "geometría", "arabic": "هندسة", "persian": "هندسه"},
+    "algebra": {"french": "algèbre", "spanish": "álgebra", "arabic": "جبر", "persian": "جبر"},
+    "calculus": {"french": "calcul", "spanish": "cálculo", "arabic": "حساب التفاضل", "persian": "حساب دیفرانسیل"},
+    "logarithm": {"french": "logarithme", "spanish": "logaritmo", "arabic": "لوغاريتم", "persian": "لگاریتم"},
+    "polynomial": {"french": "polynôme", "spanish": "polinomio", "arabic": "متعددة الحدود", "persian": "چندجمله‌ای"},
+    "coefficient": {"french": "coefficient", "spanish": "coeficiente", "arabic": "معامل", "persian": "ضریب"},
+    "symmetry": {"french": "symétrie", "spanish": "simetría", "arabic": "تناظر", "persian": "تقارن"},
+}
+
+
 def _row(english: str, chinese: str, cat: str, diff: int, pos: str = "noun") -> dict:
+    en_key = english.strip().lower()
+    langs = MULTI_LANG.get(en_key, {})
     return {
         "english": english.strip(),
         "chinese": chinese.strip(),
+        "french": langs.get("french", ""),
+        "spanish": langs.get("spanish", ""),
+        "arabic": langs.get("arabic", ""),
+        "persian": langs.get("persian", ""),
         "pos": pos,
         "ex": _ex(english.strip(), cat),
         "diff": diff,
@@ -894,14 +982,58 @@ def _select_round_robin(words: list[dict], target: int) -> list[dict]:
     return chosen[:target]
 
 
+def _migrate_language_columns():
+    """Add french/spanish/arabic/persian columns to an existing words table."""
+    import sqlite3
+    db_path = os.path.join(os.path.dirname(__file__), "english_learning.db")
+    if not os.path.exists(db_path):
+        return
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA table_info(words)")
+    existing_cols = {row[1] for row in cursor.fetchall()}
+    for col in ("french", "spanish", "arabic", "persian"):
+        if col not in existing_cols:
+            cursor.execute(f"ALTER TABLE words ADD COLUMN {col} VARCHAR(100) DEFAULT ''")
+            print(f"  [migrate] Added column '{col}' to words table")
+    conn.commit()
+    conn.close()
+
+
+def _backfill_translations():
+    """Populate multi-language translations for existing words using MULTI_LANG dict."""
+    db = SessionLocal()
+    updated = 0
+    for word in db.query(Word).all():
+        en_key = word.english.strip().lower()
+        langs = MULTI_LANG.get(en_key)
+        if not langs:
+            continue
+        changed = False
+        for lang_field in ("french", "spanish", "arabic", "persian"):
+            val = langs.get(lang_field, "")
+            if val and (getattr(word, lang_field, "") or "") == "":
+                setattr(word, lang_field, val)
+                changed = True
+        if changed:
+            updated += 1
+    if updated:
+        db.commit()
+        print(f"  [backfill] Updated translations for {updated} words")
+    db.close()
+
+
 def seed():
     Base.metadata.create_all(bind=engine)
+    _migrate_language_columns()
+
     db = SessionLocal()
     existing_count = db.query(Word).count()
     if existing_count > 0:
         print(f"Database already has {existing_count} words. Skipping seed.")
         print("To re-seed, delete english_learning.db in the backend folder and run again.")
         db.close()
+        _backfill_translations()
         return
 
     print("=" * 60)
@@ -922,6 +1054,10 @@ def seed():
             word = Word(
                 english=w["english"],
                 chinese=w["chinese"],
+                french=w.get("french", ""),
+                spanish=w.get("spanish", ""),
+                arabic=w.get("arabic", ""),
+                persian=w.get("persian", ""),
                 part_of_speech=w["pos"],
                 example_sentence=w["ex"],
                 difficulty_level=w["diff"],

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -1,10 +1,37 @@
 import { useEffect, useState, useMemo } from 'react';
 import { generateQuiz, submitQuiz, getCategories } from '../services/api';
-import type { Quiz, QuizSubmitResult } from '../types';
+import type { Quiz, QuizQuestion, QuizSubmitResult } from '../types';
 import { Alert } from '../components/Alert';
 
 type Phase = 'setup' | 'playing' | 'result';
-type QuizMode = 'en_to_cn' | 'cn_to_en';
+type QuizMode = 'en_to_target' | 'target_to_en';
+type TargetLanguage = 'chinese' | 'french' | 'spanish' | 'arabic' | 'persian';
+
+const TARGET_LANG_LABELS: Record<TargetLanguage, string> = {
+  chinese: 'Chinese (中文)',
+  french: 'French (Français)',
+  spanish: 'Spanish (Español)',
+  arabic: 'Arabic (العربية)',
+  persian: 'Persian (فارسی)',
+};
+
+const TARGET_LANG_SHORT: Record<TargetLanguage, string> = {
+  chinese: 'Chinese',
+  french: 'French',
+  spanish: 'Spanish',
+  arabic: 'Arabic',
+  persian: 'Persian',
+};
+
+const RTL_LANGUAGES = new Set<TargetLanguage>(['arabic', 'persian']);
+
+function isRtl(lang: TargetLanguage): boolean {
+  return RTL_LANGUAGES.has(lang);
+}
+
+function getTranslation(q: QuizQuestion, lang: TargetLanguage): string {
+  return q[lang] || q.chinese;
+}
 
 /** Matches `category` in seed.py — English short labels only. */
 const QUIZ_CATEGORY_ORDER = [
@@ -47,7 +74,12 @@ export default function QuizPage() {
   const [result, setResult] = useState<QuizSubmitResult | null>(null);
   const [quizMode, setQuizMode] = useState<QuizMode>(() => {
     const saved = localStorage.getItem('quiz_mode');
-    return saved === 'cn_to_en' ? 'cn_to_en' : 'en_to_cn';
+    return saved === 'target_to_en' ? 'target_to_en' : 'en_to_target';
+  });
+  const [targetLang, setTargetLang] = useState<TargetLanguage>(() => {
+    const saved = localStorage.getItem('quiz_target_lang');
+    if (saved && saved in TARGET_LANG_LABELS) return saved as TargetLanguage;
+    return 'chinese';
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -63,6 +95,13 @@ export default function QuizPage() {
     localStorage.setItem('quiz_mode', mode);
   };
 
+  const handleLangChange = (lang: TargetLanguage) => {
+    setTargetLang(lang);
+    localStorage.setItem('quiz_target_lang', lang);
+  };
+
+  const rtlActive = isRtl(targetLang);
+
   const startQuiz = async () => {
     setLoading(true);
     setError('');
@@ -70,8 +109,9 @@ export default function QuizPage() {
       const req = {
         category: selectedCategory || undefined,
         count: questionCount,
-        quiz_type: quizMode === 'cn_to_en' ? 'cn_to_en' : 'multiple_choice',
+        quiz_type: quizMode === 'target_to_en' ? 'cn_to_en' : 'multiple_choice',
         difficulty: selectedDifficulty || undefined,
+        target_language: targetLang,
       };
       const res = await generateQuiz(req);
       setQuiz(res.data);
@@ -79,15 +119,15 @@ export default function QuizPage() {
       setAnswers({});
       setPhase('playing');
     } catch (err: unknown) {
-      // Fallback for sparse categories: retry with all categories.
       if (selectedCategory) {
         try {
           const fallback = await generateQuiz({
             category: undefined,
             count: questionCount,
             difficulty: selectedDifficulty || undefined,
+            target_language: targetLang,
           });
-       
+
           setQuiz(fallback.data);
           setCurrentQ(0);
           setAnswers({});
@@ -175,29 +215,44 @@ export default function QuizPage() {
           </div>
 
           <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Target Language</label>
+            <select
+              value={targetLang}
+              onChange={(e) => handleLangChange(e.target.value as TargetLanguage)}
+              className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 outline-none"
+            >
+              {(Object.keys(TARGET_LANG_LABELS) as TargetLanguage[]).map((lang) => (
+                <option key={lang} value={lang}>
+                  {TARGET_LANG_LABELS[lang]}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">Quiz Mode</label>
             <div className="flex gap-2">
               <button
                 type="button"
-                onClick={() => handleModeChange('en_to_cn')}
+                onClick={() => handleModeChange('en_to_target')}
                 className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium border-2 transition cursor-pointer ${
-                  quizMode === 'en_to_cn'
+                  quizMode === 'en_to_target'
                     ? 'border-indigo-600 bg-indigo-50 text-indigo-700'
                     : 'border-gray-200 text-gray-600 hover:border-gray-300'
                 }`}
               >
-                English → Chinese
+                English → {TARGET_LANG_SHORT[targetLang]}
               </button>
               <button
                 type="button"
-                onClick={() => handleModeChange('cn_to_en')}
+                onClick={() => handleModeChange('target_to_en')}
                 className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium border-2 transition cursor-pointer ${
-                  quizMode === 'cn_to_en'
+                  quizMode === 'target_to_en'
                     ? 'border-indigo-600 bg-indigo-50 text-indigo-700'
                     : 'border-gray-200 text-gray-600 hover:border-gray-300'
                 }`}
               >
-                Chinese → English
+                {TARGET_LANG_SHORT[targetLang]} → English
               </button>
             </div>
           </div>
@@ -233,6 +288,8 @@ export default function QuizPage() {
     const question = quiz.questions[currentQ];
     const totalQ = quiz.questions.length;
     const answeredCount = Object.keys(answers).length;
+    const questionIsRtl = quizMode === 'target_to_en' && rtlActive;
+    const optionsAreRtl = quizMode === 'en_to_target' && rtlActive;
 
     return (
       <div className="max-w-lg mx-auto space-y-6">
@@ -257,10 +314,17 @@ export default function QuizPage() {
         {/* Question card */}
         <div className="part-box p-6">
           <p className="text-sm text-gray-400 mb-2">
-            {quizMode === 'cn_to_en' ? 'What is the English translation?' : 'What does this word mean?'}
+            {quizMode === 'target_to_en'
+              ? 'What is the English translation?'
+              : `What is the ${TARGET_LANG_SHORT[targetLang]} translation?`}
           </p>
-          <h2 className="text-3xl font-bold text-gray-900 mb-6">
-            {quizMode === 'cn_to_en' ? question.chinese : question.english}
+          <h2
+            className="text-3xl font-bold text-gray-900 mb-6"
+            dir={questionIsRtl ? 'rtl' : undefined}
+          >
+            {quizMode === 'target_to_en'
+              ? getTranslation(question, targetLang)
+              : question.english}
           </h2>
 
           <div className="grid grid-cols-1 gap-3">
@@ -268,11 +332,12 @@ export default function QuizPage() {
               <button
                 key={option}
                 onClick={() => selectAnswer(question.id, option)}
+                dir={optionsAreRtl ? 'rtl' : undefined}
                 className={`w-full text-left px-4 py-3 rounded-lg border-2 transition font-medium cursor-pointer ${
                   answers[question.id] === option
                     ? 'border-indigo-600 bg-indigo-50 text-indigo-700'
                     : 'border-gray-200 hover:border-gray-300 text-gray-700'
-                }`}
+                } ${optionsAreRtl ? 'text-right' : ''}`}
               >
                 {option}
               </button>
@@ -346,9 +411,12 @@ export default function QuizPage() {
                     </span>
                     {question && (
                       <p className="text-lg font-bold text-gray-900 mt-1">
-                        {quizMode === 'cn_to_en' ? question.chinese : question.english}
-                        <span className="text-sm font-normal text-gray-500 ml-2">
-                          ({quizMode === 'cn_to_en' ? question.english : question.chinese})
+                        {question.english}
+                        <span
+                          className="text-sm font-normal text-gray-500 ml-2"
+                          dir={rtlActive ? 'rtl' : undefined}
+                        >
+                          ({getTranslation(question, targetLang)})
                         </span>
                       </p>
                     )}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -67,7 +67,7 @@ export const submitReview = (wordId: number, knew: boolean) =>
   api.post(`/words/${wordId}/review`, { knew });
 
 // Quiz
-export const generateQuiz = (params: { category?: string; count?: number; quiz_type?: string; difficulty?: number }) =>
+export const generateQuiz = (params: { category?: string; count?: number; quiz_type?: string; difficulty?: number; target_language?: string }) =>
   api.post<Quiz>('/quiz/generate', params);
 
 export const submitQuiz = (quizId: number, answers: { question_id: number; user_answer: string }[]) =>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -44,6 +44,10 @@ export interface QuizQuestion {
   word_id: number;
   english: string;
   chinese: string;
+  french: string;
+  spanish: string;
+  arabic: string;
+  persian: string;
   options: string[];
   correct_answer: string | null;
 }


### PR DESCRIPTION
## Summary
Closes #117

- **Backend**: Added `french`, `spanish`, `arabic`, `persian` columns to the `Word` model, extended `QuizGenerateRequest` with `target_language` parameter, and updated the quiz generate endpoint to return options in the selected language (filtering out words without translations)
- **Seed data**: Added a `MULTI_LANG` dictionary with 80+ curated translations across all 5 categories, plus automatic DB migration (`ALTER TABLE`) and backfill for existing databases
- **Frontend**: Replaced the fixed EN↔CN toggle with a Target Language dropdown (Chinese, French, Spanish, Arabic, Persian) and dynamic Quiz Mode buttons; added `dir="rtl"` support for Arabic and Persian text; language preference is persisted in `localStorage`

## Affected Files
- `backend/app/models/word.py` — new translation columns
- `backend/app/schemas/quiz.py` — `target_language` field in request, language fields in response
- `backend/app/routers/quiz.py` — dynamic language-based option generation
- `backend/seed.py` — translation dictionary, migration helper, backfill logic
- `frontend/src/types/index.ts` — added language fields to `QuizQuestion`
- `frontend/src/services/api.ts` — added `target_language` param to `generateQuiz`
- `frontend/src/pages/QuizPage.tsx` — language selector dropdown, RTL support

## Test plan
- [ ] Select each target language and verify quiz generates with correct translations
- [ ] Verify Arabic/Persian options display with RTL text direction
- [ ] Confirm language preference persists across page refreshes
- [ ] Test reverse mode (Target → English) for each language
- [ ] Verify Chinese (default) still works as before
- [ ] Run seed.py on existing DB to confirm migration and backfill