### PR TITLE
feat: add CSU & Changsha locally themed vocabulary and dashboard content

### DIFF
--- a/backend/seed.py
+++ b/backend/seed.py
@@ -36,6 +36,7 @@ MAJOR_ZH = {
     "civil_engineering": "土木工程",
     "transportation_engineering": "交通工程/交通设备与控制工程",
     "mathematics": "数学与应用数学",
+    "csu_changsha": "中南大学·长沙校园生活",
 }
 
 TARGET_WORD_COUNT = 3000
@@ -43,6 +44,8 @@ TARGET_WORD_COUNT = 3000
 
 def _ex(english: str, cat: str) -> str:
     """Short example sentence, ASCII-friendly."""
+    if cat == "csu_changsha":
+        return f"At DIICSU in Changsha, students often use '{english}' in daily campus life."
     m = MAJOR_ZH.get(cat, "工程专业")
     return f"In first-year {cat.replace('_', ' ')} courses, students meet '{english}' ({m})."
 
@@ -914,6 +917,63 @@ fixed point|不动点|3
     return rows
 
 
+def _csu_changsha_lexicon() -> list[dict]:
+    """CSU campus landmarks, Changsha culture, and university life vocabulary."""
+    block = r"""
+library|图书馆|1
+cafeteria|食堂|1
+dormitory|宿舍|1
+laboratory|实验室|1
+lecture hall|阶梯教室|1
+campus|校园|1
+playground|操场|1
+gymnasium|体育馆|1
+auditorium|礼堂|2
+classroom|教室|1
+teaching building|教学楼|1
+student center|学生活动中心|2
+canteen|餐厅|1
+Orange Island|橘子洲|1
+stinky tofu|臭豆腐|1
+Yuelu Academy|岳麓书院|2
+Hunan cuisine|湘菜|1
+Yuelu Mountain|岳麓山|1
+Xiang River|湘江|1
+rice noodle|米粉|1
+hot pot|火锅|1
+spicy|辣的|1
+red braised pork|红烧肉|2
+Taiping Street|太平街|2
+Window of the World|世界之窗|2
+Mao Zedong statue|毛泽东雕像|2
+Changsha subway|长沙地铁|1
+high-speed rail|高铁|1
+semester|学期|1
+enrollment|注册入学|2
+scholarship|奖学金|1
+thesis|论文|2
+graduation|毕业|1
+tuition|学费|2
+credits|学分|1
+major|专业|1
+professor|教授|1
+exam|考试|1
+coursework|课程作业|1
+GPA|绩点|2
+freshman|大一新生|1
+sophomore|大二学生|2
+assignment|作业|1
+elective|选修课|2
+compulsory|必修课|2
+internship|实习|2
+diploma|文凭|2
+transcript|成绩单|2
+orientation|新生入学教育|2
+exchange student|交换生|2
+"""
+    return _parse_pipe_block(block, "csu_changsha")
+
+
 def _collect_all() -> list[dict]:
     buckets = [
         _computer_science_lexicon(),
@@ -921,6 +981,7 @@ def _collect_all() -> list[dict]:
         _civil_lexicon(),
         _transport_lexicon(),
         _math_lexicon(),
+        _csu_changsha_lexicon(),
     ]
     flat: list[dict] = []
     for b in buckets:
@@ -949,6 +1010,7 @@ def _select_round_robin(words: list[dict], target: int) -> list[dict]:
         "civil_engineering",
         "transportation_engineering",
         "mathematics",
+        "csu_changsha",
     ]
     per_cap = max(target // len(order), 1)
     by_cat: dict[str, list[dict]] = {c: [] for c in order}
@@ -1066,18 +1128,17 @@ def seed():
             db.add(word)
         
         db.commit()
-        progress = min(i + batch_size, len(unique_words))
-        percentage = (progress / len(unique_words)) * 100
-        print(f"  Progress: {progress}/{len(unique_words)} ({percentage:.1f}%)")
+        progress = min(i + batch_size, len(all_w))
+        percentage = (progress / len(all_w)) * 100
+        print(f"  Progress: {progress}/{len(all_w)} ({percentage:.1f}%)")
     
     final_count = db.query(Word).count()
     print("\n" + "=" * 60)
-    print(f"✓ SUCCESS! Seeded {final_count} words into the database!")
+    print(f"SUCCESS! Seeded {final_count} words into the database!")
     print("=" * 60)
     
-    # Print category breakdown
     category_counts = {}
-    for w in unique_words:
+    for w in all_w:
         cat = w['cat']
         category_counts[cat] = category_counts.get(cat, 0) + 1
     
@@ -1087,7 +1148,7 @@ def seed():
     
     print("\nDifficulty breakdown:")
     diff_counts = {1: 0, 2: 0, 3: 0}
-    for w in unique_words:
+    for w in all_w:
         diff_counts[w['diff']] = diff_counts.get(w['diff'], 0) + 1
     print(f"  - Level 1 (Easy): {diff_counts[1]} words")
     print(f"  - Level 2 (Medium): {diff_counts[2]} words")

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -10,6 +10,8 @@ const ENCOURAGEMENT_TIPS = [
   'A 15-minute review now is better than a 2-hour panic later.',
   'Confidence grows from repetition. Keep showing up.',
   'Every quiz is feedback, not judgment.',
+  'Walk around Yuelu Mountain and practice describing what you see in English.',
+  'Try ordering stinky tofu in English next time — even if the vendor laughs!',
 ];
 
 const CULTURE_TIPS = [
@@ -18,6 +20,9 @@ const CULTURE_TIPS = [
   'Cross-cultural tip: keep one phrase notebook for formal classroom communication.',
   'Study culture tip: discuss one new term with a classmate each day.',
   'Global mindset tip: explain one concept in both Chinese and English to deepen understanding.',
+  'Changsha tip: visit Orange Island (橘子洲) and describe the scenery in English to a friend.',
+  'Campus tip: try the new "CSU & Changsha" quiz category to learn campus and local vocabulary!',
+  'Foodie tip: learn the English names of Hunan dishes — great icebreaker with exchange students.',
 ];
 
 export default function DashboardPage() {
@@ -151,11 +156,11 @@ export default function DashboardPage() {
     <div className="space-y-6">
       <section className="grid grid-cols-1 lg:grid-cols-3 gap-4">
         <div className="lg:col-span-2 rounded-3xl bg-gradient-to-br from-stone-700 via-slate-700 to-indigo-700 p-7 text-white shadow-lg">
-          <p className="text-xs uppercase tracking-[0.2em] text-slate-200">DIICSU Freshman Hub</p>
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-200">DIICSU Freshman Hub · Central South University, Changsha</p>
           <h1 className="text-3xl font-bold mt-2">Welcome back, {username}</h1>
           <p className="text-slate-200 mt-3 max-w-2xl">{heroLine}</p>
           <p className="text-xs text-slate-300 mt-3">
-            You can click the links below to visit the CSU and Dundee websites.
+            Built for DIICSU students at CSU. Try the &quot;CSU &amp; Changsha&quot; quiz to learn campus and local vocabulary!
           </p>
           <div className="mt-4 flex flex-wrap gap-2">
             <button
@@ -348,7 +353,7 @@ export default function DashboardPage() {
         </div>
       </section>
 
-      <section className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <QuickAction
           to="/review"
           title="Review Words"
@@ -362,6 +367,13 @@ export default function DashboardPage() {
           description="Quick check"
           color="bg-orange-500"
           icon="⚡"
+        />
+        <QuickAction
+          to="/image-quiz"
+          title="Picture Guess"
+          description="Guess from images"
+          color="bg-pink-500"
+          icon="🖼️"
         />
         <QuickAction
           to="/progress"

--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -35,6 +35,7 @@ function getTranslation(q: QuizQuestion, lang: TargetLanguage): string {
 
 /** Matches `category` in seed.py — English short labels only. */
 const QUIZ_CATEGORY_ORDER = [
+  'csu_changsha',
   'computer_science',
   'mechanical_engineering',
   'civil_engineering',
@@ -43,6 +44,7 @@ const QUIZ_CATEGORY_ORDER = [
 ] as const;
 
 const QUIZ_CATEGORY_LABELS: Record<string, string> = {
+  csu_changsha: 'CSU & Changsha',
   computer_science: 'CS',
   mechanical_engineering: 'Mechanical',
   civil_engineering: 'Civil',


### PR DESCRIPTION
## Summary
Closes #115

- **Backend (`seed.py`)**: Added a new `csu_changsha` word category with 50 curated terms across three themes — campus landmarks (library, cafeteria, dormitory, lecture hall...), Changsha culture (Orange Island, stinky tofu, Yuelu Academy, Hunan cuisine...), and university life (semester, scholarship, thesis, GPA, freshman...). Each word uses campus-themed example sentences like "At DIICSU in Changsha, students often use '...' in daily campus life."
- **Frontend (`QuizPage.tsx`)**: Added `csu_changsha` as the first entry in the quiz category selector with the label "CSU & Changsha", making it prominent and easy to find
- **Frontend (`DashboardPage.tsx`)**: Updated hero section subtitle to reference CSU and Changsha, added Changsha-themed encouragement tips (Yuelu Mountain, stinky tofu) and culture tips (Orange Island, Hunan dishes, campus quiz category), added Picture Guess quick action card

## Affected Files
- `backend/seed.py` — new `_csu_changsha_lexicon()` function, updated `MAJOR_ZH`, `_ex()`, and `_collect_all()`
- `frontend/src/pages/QuizPage.tsx` — added `csu_changsha` to category order and labels
- `frontend/src/pages/DashboardPage.tsx` — CSU-themed welcome text, new tips, Picture Guess quick action

## Test plan
- [ ] Delete `english_learning.db` and run `python seed.py` to verify csu_changsha words are seeded
- [ ] Open Quiz page and verify "CSU & Changsha" appears first in category dropdown
- [ ] Generate a quiz with "CSU & Changsha" category and verify campus/culture/uni-life words appear
- [ ] Check Dashboard hero section shows CSU subtitle and new tips appear in Daily Inspiration