### PR TITLE
Save oral practice results to backend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,8 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import engine, Base
-from app.routers import auth, words, quiz, progress, listening, image_quiz
+from app.models import oral_practice  # noqa: F401 — register OralPracticeAttempt for create_all
+from app.routers import auth, words, quiz, progress, listening, image_quiz, oral_practice as oral_practice_router
 
 Base.metadata.create_all(bind=engine)
 
@@ -32,6 +33,7 @@ app.include_router(quiz.router)
 app.include_router(progress.router)
 app.include_router(listening.router)
 app.include_router(image_quiz.router)
+app.include_router(oral_practice_router.router)
 
 
 @app.get("/")

--- a/backend/app/models/oral_practice.py
+++ b/backend/app/models/oral_practice.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class OralPracticeAttempt(Base):
+    __tablename__ = "oral_practice_attempts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    question_id = Column(Integer, nullable=False)
+    category = Column(String(32), nullable=False)
+    difficulty = Column(String(16), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User", back_populates="oral_practice_attempts")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -16,3 +16,6 @@ class User(Base):
 
     word_progress = relationship("UserWordProgress", back_populates="user")
     quizzes = relationship("Quiz", back_populates="user")
+    oral_practice_attempts = relationship(
+        "OralPracticeAttempt", back_populates="user", cascade="all, delete-orphan"
+    )

--- a/backend/app/routers/oral_practice.py
+++ b/backend/app/routers/oral_practice.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.oral_practice import OralPracticeAttempt
+from app.models.user import User
+from app.schemas.oral_practice import OralPracticeAttemptCreate, OralPracticeAttemptOut
+from app.services.auth import get_current_user
+
+ALLOWED_CATEGORIES = frozenset(
+    {"cs", "mechanical", "civil", "transportation", "math"},
+)
+
+router = APIRouter(prefix="/api/oral-practice", tags=["oral-practice"])
+
+
+@router.post("/attempt", response_model=OralPracticeAttemptOut)
+def record_attempt(
+    body: OralPracticeAttemptCreate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    if body.category not in ALLOWED_CATEGORIES:
+        raise HTTPException(status_code=400, detail="Invalid category")
+
+    row = OralPracticeAttempt(
+        user_id=user.id,
+        question_id=body.question_id,
+        category=body.category,
+        difficulty=body.difficulty,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/history", response_model=list[OralPracticeAttemptOut])
+def list_history(
+    limit: int = Query(default=50, ge=1, le=200),
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    rows = (
+        db.query(OralPracticeAttempt)
+        .filter(OralPracticeAttempt.user_id == user.id)
+        .order_by(OralPracticeAttempt.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+    return rows

--- a/backend/app/routers/progress.py
+++ b/backend/app/routers/progress.py
@@ -9,6 +9,7 @@ from app.models.user import User
 from app.models.word import Word
 from app.models.progress import UserWordProgress
 from app.models.quiz import Quiz
+from app.models.oral_practice import OralPracticeAttempt
 from app.schemas.progress import ProgressSummary, DailyProgress
 from app.services.auth import get_current_user
 
@@ -36,6 +37,10 @@ def get_summary(
 
     total_quizzes = db.query(Quiz).filter(Quiz.user_id == user.id).count()
 
+    total_oral_attempts = (
+        db.query(OralPracticeAttempt).filter(OralPracticeAttempt.user_id == user.id).count()
+    )
+
     avg_score_result = (
         db.query(func.avg(Quiz.score))
         .filter(Quiz.user_id == user.id)
@@ -43,7 +48,7 @@ def get_summary(
     )
     average_score = round(avg_score_result or 0, 1)
 
-    # Streak: count consecutive days with at least one review
+    # Streak: consecutive days with at least one review, quiz, or oral practice attempt
     today = datetime.now(timezone.utc).date()
     streak = 0
     for i in range(365):
@@ -59,7 +64,25 @@ def get_summary(
             )
             .first()
         )
-        if has_review:
+        has_quiz = (
+            db.query(Quiz)
+            .filter(
+                Quiz.user_id == user.id,
+                Quiz.created_at >= day_start,
+                Quiz.created_at < day_end,
+            )
+            .first()
+        )
+        has_oral = (
+            db.query(OralPracticeAttempt)
+            .filter(
+                OralPracticeAttempt.user_id == user.id,
+                OralPracticeAttempt.created_at >= day_start,
+                OralPracticeAttempt.created_at < day_end,
+            )
+            .first()
+        )
+        if has_review or has_quiz or has_oral:
             streak += 1
         else:
             if i == 0:
@@ -77,6 +100,15 @@ def get_summary(
         .count()
     )
 
+    oral_attempts_today = (
+        db.query(OralPracticeAttempt)
+        .filter(
+            OralPracticeAttempt.user_id == user.id,
+            OralPracticeAttempt.created_at >= today_start,
+        )
+        .count()
+    )
+
     return ProgressSummary(
         total_words=total_words,
         words_learned=words_learned,
@@ -85,6 +117,8 @@ def get_summary(
         average_score=average_score,
         current_streak=streak,
         reviews_today=reviews_today,
+        total_oral_attempts=total_oral_attempts,
+        oral_attempts_today=oral_attempts_today,
     )
 
 
@@ -122,6 +156,16 @@ def get_history(
             .all()
         )
 
+        oral_count = (
+            db.query(OralPracticeAttempt)
+            .filter(
+                OralPracticeAttempt.user_id == user.id,
+                OralPracticeAttempt.created_at >= day_start,
+                OralPracticeAttempt.created_at < day_end,
+            )
+            .count()
+        )
+
         quiz_count = len(day_quizzes)
         if day_quizzes:
             accuracy = round(sum(q.score for q in day_quizzes) / len(day_quizzes), 1)
@@ -134,6 +178,7 @@ def get_history(
                 reviews=reviews,
                 quizzes=quiz_count,
                 accuracy=accuracy,
+                oral_practice=oral_count,
             )
         )
 

--- a/backend/app/schemas/oral_practice.py
+++ b/backend/app/schemas/oral_practice.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class OralPracticeAttemptCreate(BaseModel):
+    question_id: int = Field(..., ge=1)
+    category: str = Field(..., min_length=1, max_length=32)
+    difficulty: str = Field(..., min_length=4, max_length=8)
+
+    @field_validator("difficulty")
+    @classmethod
+    def difficulty_allowed(cls, v: str) -> str:
+        allowed = frozenset({"easy", "medium", "hard"})
+        if v not in allowed:
+            raise ValueError("difficulty must be easy, medium, or hard")
+        return v
+
+
+class OralPracticeAttemptOut(BaseModel):
+    id: int
+    question_id: int
+    category: str
+    difficulty: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/progress.py
+++ b/backend/app/schemas/progress.py
@@ -9,6 +9,8 @@ class ProgressSummary(BaseModel):
     average_score: float
     current_streak: int
     reviews_today: int
+    total_oral_attempts: int
+    oral_attempts_today: int
 
 
 class DailyProgress(BaseModel):
@@ -16,3 +18,4 @@ class DailyProgress(BaseModel):
     reviews: int
     quizzes: int
     accuracy: float
+    oral_practice: int

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -55,6 +55,8 @@ export default function DashboardPage() {
     average_score: 0,
     current_streak: 0,
     reviews_today: 0,
+    total_oral_attempts: 0,
+    oral_attempts_today: 0,
   };
 
   const coverage = stats.total_words > 0 ? Math.round((stats.words_learned / stats.total_words) * 100) : 0;
@@ -97,8 +99,13 @@ export default function DashboardPage() {
       { label: 'Coverage', value: `${coverage}%`, tone: 'bg-indigo-50 text-indigo-700 border-indigo-100' },
       { label: 'Mastery', value: `${masteryRate}%`, tone: 'bg-orange-50 text-orange-700 border-orange-100' },
       { label: 'Avg Score', value: `${Math.round(stats.average_score)}%`, tone: 'bg-slate-100 text-slate-700 border-slate-200' },
+      {
+        label: 'Oral practice',
+        value: `${stats.total_oral_attempts} total`,
+        tone: 'bg-teal-50 text-teal-800 border-teal-100',
+      },
     ],
-    [coverage, masteryRate, stats.average_score]
+    [coverage, masteryRate, stats.average_score, stats.total_oral_attempts]
   );
 
   const shuffleTips = () => {
@@ -207,8 +214,12 @@ export default function DashboardPage() {
             <p className="text-4xl font-bold mt-1">{stats.current_streak} day{stats.current_streak !== 1 ? 's' : ''}</p>
           </div>
           <div className="text-right">
-            <p className="text-amber-100 text-sm">Reviews Completed Today</p>
+            <p className="text-amber-100 text-sm">Reviews Today</p>
             <p className="text-4xl font-bold mt-1">{stats.reviews_today}</p>
+          </div>
+          <div className="text-right">
+            <p className="text-amber-100 text-sm">Oral Attempts Today</p>
+            <p className="text-4xl font-bold mt-1">{stats.oral_attempts_today}</p>
           </div>
           <div className="text-right">
             <p className="text-amber-100 text-sm">Learning Status</p>

--- a/frontend/src/pages/OralPracticePage.tsx
+++ b/frontend/src/pages/OralPracticePage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { submitOralPracticeAttempt } from '../services/api';
 
 type Difficulty = 'easy' | 'medium' | 'hard';
 type Category = 'cs' | 'mechanical' | 'civil' | 'transportation' | 'math';
@@ -1053,8 +1054,18 @@ export default function OralPracticePage() {
     setError(null);
   }, [difficulty, category, filteredQuestions, step]);
 
+  const persistAttemptIfRecorded = () => {
+    if (!currentQuestion || !audioUrl) return;
+    void submitOralPracticeAttempt({
+      question_id: currentQuestion.id,
+      category: currentQuestion.category,
+      difficulty: currentQuestion.difficulty,
+    }).catch(() => {});
+  };
+
   const handleNextQuestion = () => {
     if (filteredQuestions.length === 0) return;
+    persistAttemptIfRecorded();
     const remaining = filteredQuestions.filter((q) => q.id !== currentQuestion?.id);
     const pool = remaining.length > 0 ? remaining : filteredQuestions;
     const next = pool[Math.floor(Math.random() * pool.length)];
@@ -1116,6 +1127,9 @@ export default function OralPracticePage() {
         <h1 className="text-2xl font-bold text-gray-900">Oral Practice</h1>
         <p className="text-gray-500 mt-1">
           Practice your speaking skills by answering random English questions and listening to your own recording.
+        </p>
+        <p className="text-xs text-gray-400 mt-2">
+          When you finish a recording and go to the next question (or return to difficulty), your attempt is saved to your account for progress and history.
         </p>
       </div>
 
@@ -1232,7 +1246,10 @@ export default function OralPracticePage() {
               </button>
               <button
                 type="button"
-                onClick={() => setStep(1)}
+                onClick={() => {
+                  persistAttemptIfRecorded();
+                  setStep(1);
+                }}
                 className="px-3 py-2 rounded-md text-xs font-medium text-gray-500 hover:text-gray-700"
               >
                 Back to difficulty

--- a/frontend/src/pages/ProgressPage.tsx
+++ b/frontend/src/pages/ProgressPage.tsx
@@ -3,16 +3,30 @@ import {
   LineChart, Line, BarChart, Bar,
   XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
 } from 'recharts';
-import { getProgressSummary, getProgressHistory, getQuizHistory } from '../services/api';
-import type { ProgressSummary, DailyProgress, QuizResult } from '../types';
+import {
+  getProgressSummary,
+  getProgressHistory,
+  getQuizHistory,
+  getOralPracticeHistory,
+} from '../services/api';
+import type { ProgressSummary, DailyProgress, QuizResult, OralPracticeAttempt } from '../types';
 import { normalizeProgressHistory } from '../utils/progressHistory';
 
 const HISTORY_DAYS = 30;
+
+const ORAL_CATEGORY_LABELS: Record<string, string> = {
+  cs: 'CS',
+  mechanical: 'Mechanical',
+  civil: 'Civil',
+  transportation: 'Transportation',
+  math: 'Math',
+};
 
 export default function ProgressPage() {
   const [summary, setSummary] = useState<ProgressSummary | null>(null);
   const [history, setHistory] = useState<DailyProgress[]>([]);
   const [quizHistory, setQuizHistory] = useState<QuizResult[]>([]);
+  const [oralHistory, setOralHistory] = useState<OralPracticeAttempt[]>([]);
   const [loading, setLoading] = useState(true);
 
   const chartHistory = useMemo(
@@ -25,11 +39,13 @@ export default function ProgressPage() {
       getProgressSummary(),
       getProgressHistory(HISTORY_DAYS),
       getQuizHistory(),
+      getOralPracticeHistory(40),
     ])
-      .then(([s, h, q]) => {
+      .then(([s, h, q, o]) => {
         setSummary(s.data);
         setHistory(h.data);
         setQuizHistory(q.data);
+        setOralHistory(o.data);
       })
       .catch(() => {})
       .finally(() => setLoading(false));
@@ -40,8 +56,15 @@ export default function ProgressPage() {
   }
 
   const stats = summary ?? {
-    total_words: 0, words_learned: 0, words_mastered: 0,
-    total_quizzes: 0, average_score: 0, current_streak: 0, reviews_today: 0,
+    total_words: 0,
+    words_learned: 0,
+    words_mastered: 0,
+    total_quizzes: 0,
+    average_score: 0,
+    current_streak: 0,
+    reviews_today: 0,
+    total_oral_attempts: 0,
+    oral_attempts_today: 0,
   };
 
   const learnedPct = stats.total_words > 0 ? Math.round((stats.words_learned / stats.total_words) * 100) : 0;
@@ -55,16 +78,18 @@ export default function ProgressPage() {
       </div>
 
       {/* Summary cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">
         <SummaryCard label="Vocabulary Coverage" value={`${learnedPct}%`} sub={`${stats.words_learned} / ${stats.total_words}`} />
         <SummaryCard label="Words Mastered" value={String(stats.words_mastered)} />
         <SummaryCard label="Total Quizzes" value={String(stats.total_quizzes)} />
         <SummaryCard label="Average Score" value={`${stats.average_score}%`} />
+        <SummaryCard label="Oral Attempts" value={String(stats.total_oral_attempts)} sub="All time" />
+        <SummaryCard label="Oral Today" value={String(stats.oral_attempts_today)} sub="This UTC day" />
       </div>
 
       <div className="grid grid-cols-1 xl:grid-cols-5 gap-4">
         <div className="xl:col-span-3 part-box p-6">
-        <h2 className="text-lg font-semibold text-slate-900 mb-4">Daily Reviews (Last 30 Days)</h2>
+        <h2 className="text-lg font-semibold text-slate-900 mb-4">Daily Activity (Last 30 Days)</h2>
         <ResponsiveContainer width="100%" height={300}>
           <BarChart data={chartHistory}>
             <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
@@ -79,6 +104,7 @@ export default function ProgressPage() {
             <Legend />
             <Bar dataKey="reviews" name="Reviews" fill="#6366f1" radius={[4, 4, 0, 0]} />
             <Bar dataKey="quizzes" name="Quizzes" fill="#f59e0b" radius={[4, 4, 0, 0]} />
+            <Bar dataKey="oral_practice" name="Oral practice" fill="#14b8a6" radius={[4, 4, 0, 0]} />
           </BarChart>
         </ResponsiveContainer>
         </div>
@@ -158,6 +184,40 @@ export default function ProgressPage() {
                         {q.score.toFixed(0)}%
                       </span>
                     </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div className="part-box p-6">
+        <h2 className="text-lg font-semibold text-slate-900 mb-4">Recent Oral Practice</h2>
+        {oralHistory.length === 0 ? (
+          <p className="text-gray-400 text-sm">No oral practice attempts yet. Complete a recording on Oral Practice to see history here.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 border-b border-gray-100">
+                  <th className="pb-3 font-medium">Date</th>
+                  <th className="pb-3 font-medium">Subject</th>
+                  <th className="pb-3 font-medium">Difficulty</th>
+                  <th className="pb-3 font-medium">Question #</th>
+                </tr>
+              </thead>
+              <tbody>
+                {oralHistory.map((row) => (
+                  <tr key={row.id} className="border-b border-gray-50">
+                    <td className="py-3 text-gray-700">
+                      {new Date(row.created_at).toLocaleString()}
+                    </td>
+                    <td className="py-3 text-gray-700">
+                      {ORAL_CATEGORY_LABELS[row.category] ?? row.category}
+                    </td>
+                    <td className="py-3 text-gray-700 capitalize">{row.difficulty}</td>
+                    <td className="py-3 text-gray-700">{row.question_id}</td>
                   </tr>
                 ))}
               </tbody>

--- a/frontend/src/pages/SpeakingPage.tsx
+++ b/frontend/src/pages/SpeakingPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Alert } from '../components/Alert';
+import { submitOralPracticeAttempt } from '../services/api';
 
 type Difficulty = 'easy' | 'medium' | 'hard';
 type Category = 'cs' | 'mechanical' | 'civil' | 'transportation' | 'math';
@@ -1054,8 +1055,18 @@ export default function OralPracticePage() {
     setError(null);
   }, [difficulty, category, filteredQuestions, step]);
 
+  const persistAttemptIfRecorded = () => {
+    if (!currentQuestion || !audioUrl) return;
+    void submitOralPracticeAttempt({
+      question_id: currentQuestion.id,
+      category: currentQuestion.category,
+      difficulty: currentQuestion.difficulty,
+    }).catch(() => {});
+  };
+
   const handleNextQuestion = () => {
     if (filteredQuestions.length === 0) return;
+    persistAttemptIfRecorded();
     const remaining = filteredQuestions.filter((q) => q.id !== currentQuestion?.id);
     const pool = remaining.length > 0 ? remaining : filteredQuestions;
     const next = pool[Math.floor(Math.random() * pool.length)];
@@ -1117,6 +1128,9 @@ export default function OralPracticePage() {
         <h1 className="text-2xl font-bold text-gray-900">Oral Practice</h1>
         <p className="text-gray-500 mt-1">
           Practice your speaking skills by answering random English questions and listening to your own recording.
+        </p>
+        <p className="text-xs text-gray-400 mt-2">
+          When you finish a recording and go to the next question (or return to difficulty), your attempt is saved to your account for progress and history.
         </p>
       </div>
 
@@ -1233,7 +1247,10 @@ export default function OralPracticePage() {
               </button>
               <button
                 type="button"
-                onClick={() => setStep(1)}
+                onClick={() => {
+                  persistAttemptIfRecorded();
+                  setStep(1);
+                }}
                 className="px-3 py-2 rounded-md text-xs font-medium text-gray-500 hover:text-gray-700"
               >
                 Back to difficulty

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -13,6 +13,7 @@ import type {
   ChangePasswordRequest,
   ImageQuiz,
   ImageQuizSubmitResult,
+  OralPracticeAttempt,
 } from '../types';
 
 const api = axios.create({
@@ -84,6 +85,16 @@ export const getProgressSummary = () =>
 
 export const getProgressHistory = (days = 30) =>
   api.get<DailyProgress[]>('/progress/history', { params: { days } });
+
+// Oral practice (speaking)
+export const submitOralPracticeAttempt = (data: {
+  question_id: number;
+  category: string;
+  difficulty: string;
+}) => api.post<OralPracticeAttempt>('/oral-practice/attempt', data);
+
+export const getOralPracticeHistory = (limit = 50) =>
+  api.get<OralPracticeAttempt[]>('/oral-practice/history', { params: { limit } });
 
 // Image Quiz
 export const getImageCategories = () =>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -90,6 +90,8 @@ export interface ProgressSummary {
   average_score: number;
   current_streak: number;
   reviews_today: number;
+  total_oral_attempts: number;
+  oral_attempts_today: number;
 }
 
 export interface DailyProgress {
@@ -97,6 +99,15 @@ export interface DailyProgress {
   reviews: number;
   quizzes: number;
   accuracy: number;
+  oral_practice: number;
+}
+
+export interface OralPracticeAttempt {
+  id: number;
+  question_id: number;
+  category: string;
+  difficulty: string;
+  created_at: string;
 }
 
 export interface ImagePromptQuestion {

--- a/frontend/src/utils/progressHistory.ts
+++ b/frontend/src/utils/progressHistory.ts
@@ -30,14 +30,21 @@ export function normalizeProgressHistory(
   for (let i = days - 1; i >= 0; i--) {
     const d = addUtcDays(today, -i);
     const iso = toISODateUTC(d);
-    out.push(
-      byDate.get(iso) ?? {
+    const row = byDate.get(iso);
+    if (row) {
+      out.push({
+        ...row,
+        oral_practice: row.oral_practice ?? 0,
+      });
+    } else {
+      out.push({
         date: iso,
         reviews: 0,
         quizzes: 0,
         accuracy: 0,
-      },
-    );
+        oral_practice: 0,
+      });
+    }
   }
 
   return out;

--- a/github_tests/test_progress.py
+++ b/github_tests/test_progress.py
@@ -129,6 +129,10 @@ def test_progress_summary_and_history(client, auth_token):
     assert data["average_score"] >= 0.0
     assert data["reviews_today"] >= 1
     assert data["current_streak"] >= 1
+    assert "total_oral_attempts" in data
+    assert "oral_attempts_today" in data
+    assert isinstance(data["total_oral_attempts"], int)
+    assert isinstance(data["oral_attempts_today"], int)
 
     days = 7
     history = client.get(f"/api/progress/history?days={days}", headers=headers)
@@ -141,7 +145,7 @@ def test_progress_summary_and_history(client, auth_token):
     assert items[-1]["date"] == today
 
     for item in items:
-        assert set(item.keys()) == {"date", "reviews", "quizzes", "accuracy"}
+        assert set(item.keys()) == {"date", "reviews", "quizzes", "accuracy", "oral_practice"}
         assert isinstance(item["date"], str)
         assert isinstance(item["reviews"], int)
         assert isinstance(item["quizzes"], int)


### PR DESCRIPTION
## Changes
- Expanded the Oral Practice question bank in frontend/src/pages/OralPracticePage.tsx: added 10 new questions per category (cs, mechanical, civil, transportation, math), question IDs 71–120, and extended questionAnswers for those IDs.
- Fixed React issues in frontend/src/pages/ReviewPage.tsx: removed duplicate useEffect imports/declarations, corrected loadSession / useEffect structure, and avoided a progress-bar divide-by-zero when words.length === 0.
- Added backend persistence for oral/speaking practice: new OralPracticeAttempt model and table, POST /api/oral-practice/attempt and GET /api/oral-practice/history, wired in backend/app/main.py and User relationship.
- Extended progress APIs: ProgressSummary now includes total_oral_attempts and oral_attempts_today; DailyProgress includes oral_practice per day; streak logic treats a day as active if the user has reviews, quizzes, or oral attempts (backend/app/routers/progress.py, backend/app/schemas/progress.py).
- Frontend API + types: submitOralPracticeAttempt, getOralPracticeHistory, and updated ProgressSummary / DailyProgress / normalizeProgressHistory for oral_practice.
- Save attempts from OralPracticePage.tsx and SpeakingPage.tsx when the user has finished a recording (audioUrl) and taps Next Question or Back to difficulty (failures do not block the UI).
- Dashboard and Progress: show oral totals/today, daily chart series for oral practice, and a “Recent Oral Practice” table; updated github_tests/test_progress.py for new progress fields.

## Purpose
- Give learners more Oral Practice content per subject and keep the review page building and stable on edge cases.
- Store oral/speaking practice attempts server-side so progress is durable, visible on the dashboard and progress history, and reflected in streaks and daily activity.
## Test Result
- Ran npm run build in frontend (tsc -b && vite build); it completed successfully with no TypeScript/compile errors.


## Related Issue
Fixes #67

## Type of Change
- [x ] Feature
- [x ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Docs
- [ ] Test

## Checklist
- [x] Code builds locally
- [x] No new warnings/errors
- [x] PR ready for review