### PR TITLE
﻿fix: add server-side logout token invalidation

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -11,7 +11,14 @@ from app.schemas.user import (
     UserUpdate,
     ChangePasswordRequest,
 )
-from app.services.auth import hash_password, verify_password, create_access_token, get_current_user
+from app.services.auth import (
+    hash_password,
+    verify_password,
+    create_access_token,
+    get_current_user,
+    oauth2_scheme,
+    revoke_token,
+)
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
@@ -94,3 +101,12 @@ def change_password(
     user.hashed_password = hash_password(req.new_password)
     db.commit()
     return {"detail": "Password updated"}
+
+
+@router.post("/logout")
+def logout(
+    token: str = Depends(oauth2_scheme),
+    _: User = Depends(get_current_user),
+):
+    revoke_token(token)
+    return {"detail": "Logged out"}

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 
 import bcrypt
 from jose import JWTError, jwt
@@ -15,6 +16,13 @@ ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 1440  # 24 hours
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
+_TOKEN_BLOCKLIST: dict[str, datetime] = {}
+
+
+def _cleanup_blocklist(now: datetime) -> None:
+    expired = [jti for jti, exp in _TOKEN_BLOCKLIST.items() if exp <= now]
+    for jti in expired:
+        _TOKEN_BLOCKLIST.pop(jti, None)
 
 
 def hash_password(password: str) -> str:
@@ -30,8 +38,24 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 def create_access_token(data: dict) -> str:
     to_encode = data.copy()
     expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-    to_encode.update({"exp": expire})
+    to_encode.update({"exp": expire, "jti": str(uuid4())})
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def revoke_token(token: str) -> None:
+    now = datetime.now(timezone.utc)
+    _cleanup_blocklist(now)
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        jti: str | None = payload.get("jti")
+        exp = payload.get("exp")
+        if jti is None or exp is None:
+            return
+        exp_dt = datetime.fromtimestamp(float(exp), tz=timezone.utc)
+        _TOKEN_BLOCKLIST[jti] = exp_dt
+    except JWTError:
+        # Invalid/expired tokens are treated as already unusable.
+        return
 
 
 def get_current_user(
@@ -44,6 +68,11 @@ def get_current_user(
     )
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        jti: str | None = payload.get("jti")
+        if jti is not None:
+            _cleanup_blocklist(datetime.now(timezone.utc))
+            if jti in _TOKEN_BLOCKLIST:
+                raise credentials_exception
         sub: str | None = payload.get("sub")
         if sub is None:
             raise credentials_exception

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -53,3 +53,26 @@ def test_login_wrong_password(client):
         "password": "wrongpassword",
     })
     assert response.status_code == 401
+
+
+def test_logout_invalidates_token(client):
+    client.post("/api/auth/register", json={
+        "username": "logoutuser",
+        "email": "logout@example.com",
+        "password": "Password123",
+    })
+    login_resp = client.post("/api/auth/login", json={
+        "username": "logoutuser",
+        "password": "Password123",
+    })
+    token = login_resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    me_before = client.get("/api/auth/me", headers=headers)
+    assert me_before.status_code == 200
+
+    logout_resp = client.post("/api/auth/logout", headers=headers)
+    assert logout_resp.status_code == 200
+
+    me_after = client.get("/api/auth/me", headers=headers)
+    assert me_after.status_code == 401

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
-import { login as apiLogin, register as apiRegister } from '../services/api';
+import { login as apiLogin, register as apiRegister, logout as apiLogout } from '../services/api';
 
 interface AuthContextType {
   token: string | null;
@@ -48,6 +48,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const logout = () => {
+    void apiLogout().catch(() => {});
     localStorage.removeItem('token');
     localStorage.removeItem('username');
     setToken(null);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -47,6 +47,9 @@ export const register = (data: { username: string; email: string; password: stri
 export const login = (data: { username: string; password: string }) =>
   api.post<Token>('/auth/login', data);
 
+export const logout = () =>
+  api.post<{ detail: string }>('/auth/logout');
+
 export const getMe = () => api.get<User>('/auth/me');
 
 export const updateMe = (data: UserUpdate) => api.put<User>('/auth/me', data);


### PR DESCRIPTION
## Changes
- Implemented server-side logout with token invalidation:
   - Added POST /api/auth/logout in backend/app/routers/auth.py.
   - Added JWT revocation support in backend/app/services/auth.py using jti and an in-memory blocklist.
   - Updated authentication checks to reject revoked tokens in get_current_user.
- Updated token generation to include a unique jti claim for each issued access token.
- Updated frontend logout flow:
   - Added logout API call in frontend/src/services/api.ts.
   - Updated frontend/src/hooks/useAuth.tsx so logout now calls backend logout first, then clears local storage/session state.
-Added backend test coverage:
   - backend/tests/test_auth.py now includes test_logout_invalidates_token, verifying token works before logout and is rejected after logout.
   

## Purpose
-Ensure French quiz mode is actually usable in real-world data conditions where French translations may be incomplete.
- Prevent backend startup failures on older SQLite schemas while preserving the French backfill behavior when supported.
## Test Result
- Ran frontend build: npm run build (tsc -b && vite build) and it passed successfully.
- Added backend logout test for token invalidation behavior (test_logout_invalidates_token).


## Related Issue
Fixes #74 

## Type of Change
- [x ] Feature
- [x ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Docs
- [ ] Test

## Checklist
- [x] Code builds locally
- [x] No new warnings/errors
- [x] PR ready for review