### PR TITLE
fix: use Alert for microphone errors on Oral Practice page

### DIFF
--- a/frontend/src/pages/OralPracticePage.tsx
+++ b/frontend/src/pages/OralPracticePage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Alert } from '../components/Alert';
 import { submitOralPracticeAttempt } from '../services/api';
 
 type Difficulty = 'easy' | 'medium' | 'hard';
@@ -1255,7 +1256,11 @@ export default function OralPracticePage() {
                 Back to difficulty
               </button>
             </div>
-            {error && <p className="text-sm text-red-500 mt-2">{error}</p>}
+            {error && (
+              <Alert variant="error" className="mt-2">
+                {error}
+              </Alert>
+            )}
             {audioUrl && (
               <div className="mt-4 space-y-1">
                 <p className="text-sm text-gray-600">Your recording:</p>


### PR DESCRIPTION
## Summary
Closes #132

- Replace the plain red error paragraph with the shared `Alert` component (`variant="error"`) and preserve spacing with `className="mt-2"`.

## Affected files
- `frontend/src/pages/OralPracticePage.tsx`

## Test plan
- [ ] Open Oral Practice, trigger a microphone permission denial or similar error and confirm the message renders as an Alert