### PR TITLE
fix: add cursor-pointer to Review save-error dismiss control

### DIFF
--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -156,7 +156,7 @@ export default function ReviewPage() {
             <span>{saveError}</span>
             <button
               onClick={() => setSaveError(null)}
-              className="shrink-0 text-red-500 hover:text-red-700 font-bold leading-none"
+              className="shrink-0 text-red-500 hover:text-red-700 font-bold leading-none cursor-pointer transition"
               aria-label="Dismiss"
             >
               ×


### PR DESCRIPTION
## Summary
Closes #133

- Add `cursor-pointer` and `transition` to the dismiss (×) button on the save-error `Alert` on the Review page.

## Affected files
- `frontend/src/pages/ReviewPage.tsx`

## Test plan
- [ ] Trigger a save error (e.g. offline) and hover the × control; cursor should be a pointer