### PR TITLE
fix: add cursor-pointer to login and register links

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -76,7 +76,7 @@ export default function LoginPage() {
 
         <p className="text-center text-sm text-slate-600 mt-6">
           Don't have an account?{' '}
-          <Link to="/register" className="text-indigo-600 font-medium hover:underline">
+          <Link to="/register" className="text-indigo-600 font-medium hover:underline cursor-pointer">
             Sign up
           </Link>
         </p>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -131,7 +131,7 @@ export default function RegisterPage() {
 
         <p className="text-center text-sm text-slate-600 mt-6">
           Already have an account?{' '}
-          <Link to="/login" className="text-indigo-600 font-medium hover:underline">
+          <Link to="/login" className="text-indigo-600 font-medium hover:underline cursor-pointer">
             Sign in
           </Link>
         </p>


### PR DESCRIPTION
## Summary
Closes #135

- **Login (`LoginPage.tsx`)**: Add `cursor-pointer` to the "Sign up" link at the bottom of the form so hover matches the primary submit button affordance.
- **Register (`RegisterPage.tsx`)**: Add `cursor-pointer` to the "Sign in" link for the same consistency.

## Affected Files
- `frontend/src/pages/LoginPage.tsx` — bottom `Link` to `/register`
- `frontend/src/pages/RegisterPage.tsx` — bottom `Link` to `/login`

## Test plan
- [ ] Open `/login`, hover "Sign up"; cursor should be a pointer
- [ ] Open `/register`, hover "Sign in"; cursor should be a pointer