### PR TITLE
fix: add cursor-pointer to Oral Practice step controls

### DIFF
--- a/frontend/src/pages/OralPracticePage.tsx
+++ b/frontend/src/pages/OralPracticePage.tsx
@@ -1144,7 +1144,7 @@ export default function OralPracticePage() {
               <button
                 type="button"
                 onClick={() => setDifficulty('easy')}
-                className={`px-4 py-2 rounded-md text-sm font-medium border ${
+                className={`px-4 py-2 rounded-md text-sm font-medium border cursor-pointer transition ${
                   difficulty === 'easy'
                     ? 'bg-indigo-600 text-white border-indigo-600'
                     : 'bg-white text-gray-700 border-gray-200'
@@ -1155,7 +1155,7 @@ export default function OralPracticePage() {
               <button
                 type="button"
                 onClick={() => setDifficulty('medium')}
-                className={`px-4 py-2 rounded-md text-sm font-medium border ${
+                className={`px-4 py-2 rounded-md text-sm font-medium border cursor-pointer transition ${
                   difficulty === 'medium'
                     ? 'bg-indigo-600 text-white border-indigo-600'
                     : 'bg-white text-gray-700 border-gray-200'
@@ -1166,7 +1166,7 @@ export default function OralPracticePage() {
               <button
                 type="button"
                 onClick={() => setDifficulty('hard')}
-                className={`px-4 py-2 rounded-md text-sm font-medium border ${
+                className={`px-4 py-2 rounded-md text-sm font-medium border cursor-pointer transition ${
                   difficulty === 'hard'
                     ? 'bg-indigo-600 text-white border-indigo-600'
                     : 'bg-white text-gray-700 border-gray-200'
@@ -1178,7 +1178,7 @@ export default function OralPracticePage() {
             <button
               type="button"
               onClick={() => setStep(2)}
-              className="mt-6 inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 transition"
+              className="mt-6 inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 transition cursor-pointer"
             >
               Next: Choose subject
             </button>
@@ -1204,7 +1204,7 @@ export default function OralPracticePage() {
                   <select
                     value={category}
                     onChange={(e) => setCategory(e.target.value as Category)}
-                    className="border rounded-md px-2 py-1 text-sm text-gray-700"
+                    className="border rounded-md px-2 py-1 text-sm text-gray-700 cursor-pointer"
                   >
                     <option value="cs">CS</option>
                     <option value="mechanical">Mechanical</option>
@@ -1231,7 +1231,7 @@ export default function OralPracticePage() {
               <button
                 type="button"
                 onClick={handleToggleRecording}
-                className={`px-4 py-2 rounded-md text-sm font-medium text-white transition shadow-sm ${
+                className={`px-4 py-2 rounded-md text-sm font-medium text-white transition shadow-sm cursor-pointer ${
                   isRecording ? 'bg-red-500 hover:bg-red-600' : 'bg-indigo-600 hover:bg-indigo-700'
                 }`}
               >
@@ -1240,7 +1240,7 @@ export default function OralPracticePage() {
               <button
                 type="button"
                 onClick={handleNextQuestion}
-                className="px-4 py-2 rounded-md text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 transition"
+                className="px-4 py-2 rounded-md text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 transition cursor-pointer"
               >
                 Next Question
               </button>
@@ -1250,7 +1250,7 @@ export default function OralPracticePage() {
                   persistAttemptIfRecorded();
                   setStep(1);
                 }}
-                className="px-3 py-2 rounded-md text-xs font-medium text-gray-500 hover:text-gray-700"
+                className="px-3 py-2 rounded-md text-xs font-medium text-gray-500 hover:text-gray-700 cursor-pointer transition"
               >
                 Back to difficulty
               </button>
@@ -1263,7 +1263,7 @@ export default function OralPracticePage() {
                 <button
                   type="button"
                   onClick={() => setShowAnswer((prev) => !prev)}
-                  className="mt-3 px-4 py-2 rounded-md text-sm font-medium text-indigo-700 bg-indigo-50 hover:bg-indigo-100 transition"
+                  className="mt-3 px-4 py-2 rounded-md text-sm font-medium text-indigo-700 bg-indigo-50 hover:bg-indigo-100 transition cursor-pointer"
                 >
                   {showAnswer ? 'Hide Answer' : 'View Answer'}
                 </button>


### PR DESCRIPTION
## Summary
Closes #140

- Add `cursor-pointer` and `transition` on Step 1 difficulty buttons, Next, subject `select`, Start/Stop recording, Next Question, Back to difficulty, and View/Hide Answer so controls match the rest of the app.

## Affected Files
- `frontend/src/pages/OralPracticePage.tsx`

## Test plan
- [ ] Oral Practice: hover difficulty, Next, recording, navigation, and View Answer; pointer cursor
- [ ] Run `npm run build` in `frontend`