### PR TITLE
fix(models): register OralPracticeAttempt in package __init__ for SQL…

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,5 +2,13 @@ from app.models.user import User
 from app.models.word import Word
 from app.models.progress import UserWordProgress
 from app.models.quiz import Quiz, QuizQuestion
+from app.models.oral_practice import OralPracticeAttempt
 
-__all__ = ["User", "Word", "UserWordProgress", "Quiz", "QuizQuestion"]
+__all__ = [
+    "User",
+    "Word",
+    "UserWordProgress",
+    "Quiz",
+    "QuizQuestion",
+    "OralPracticeAttempt",
+]


### PR DESCRIPTION
## Summary
Registers `OralPracticeAttempt` in `app/models/__init__.py` so SQLAlchemy can resolve `User.oral_practice_attempts` when the models package is loaded (e.g. `seed.py` importing `Word`).

## Problem
Running `python seed.py` could raise:
`InvalidRequestError: ... 'OralPracticeAttempt' failed to locate a name`
because `OralPracticeAttempt` was never imported when `app.models` was initialized.

## Solution
- Import `OralPracticeAttempt` in `app/models/__init__.py` and add it to `__all__`.

## How to test
1. `conda activate english-learning` (or your backend venv)
2. `cd backend`
3. `python seed.py` — should complete without the mapper error (empty DB: full seed; existing words: skip + backfill per current logic)

## Checklist
- [ ] No new circular imports
- [ ] App still starts (`uvicorn app.main:app`)
- [ ] `pytest` / CI still pass (if applicable)

## Related
Closes #[issue-number] _(replace if you filed the GitHub issue)_