### PR TITLE
feat(auth): implement JWT refresh token mechanism

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import inspect, or_
 
 from app.database import engine, Base, SessionLocal
-from app.models import oral_practice, token_blacklist, writing_evaluation  # noqa: F401 — register models for create_all
+from app.models import oral_practice, refresh_token, token_blacklist, writing_evaluation  # noqa: F401 — register models for create_all
 from app.models.word import Word
 from app.routers import auth, words, quiz, progress, listening, image_quiz, oral_practice as oral_practice_router, writing
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,7 @@ from app.models.word import Word
 from app.models.progress import UserWordProgress
 from app.models.quiz import Quiz, QuizQuestion
 from app.models.oral_practice import OralPracticeAttempt
+from app.models.refresh_token import RefreshToken
 
 __all__ = [
     "User",
@@ -11,4 +12,5 @@ __all__ = [
     "Quiz",
     "QuizQuestion",
     "OralPracticeAttempt",
+    "RefreshToken",
 ]

--- a/backend/app/models/refresh_token.py
+++ b/backend/app/models/refresh_token.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class RefreshToken(Base):
+    """Stores long-lived refresh tokens used to silently reissue access tokens."""
+
+    __tablename__ = "refresh_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    token_hash = Column(String(64), unique=True, nullable=False, index=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    revoked = Column(Boolean, default=False, nullable=False)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -10,11 +10,15 @@ from app.schemas.user import (
     Token,
     UserUpdate,
     ChangePasswordRequest,
+    RefreshRequest,
 )
 from app.services.auth import (
     hash_password,
     verify_password,
     create_access_token,
+    create_refresh_token,
+    verify_and_rotate_refresh_token,
+    revoke_all_refresh_tokens,
     get_current_user,
     blacklist_token,
     purge_expired_blacklist,
@@ -49,8 +53,28 @@ def login(credentials: UserLogin, db: Session = Depends(get_db)):
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
         )
-    token = create_access_token(data={"sub": str(user.id)})
-    return {"access_token": token, "token_type": "bearer"}
+    access_token = create_access_token(data={"sub": str(user.id)})
+    refresh_token = create_refresh_token(user.id, db)
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+    }
+
+
+@router.post("/refresh", response_model=Token)
+def refresh(body: RefreshRequest, db: Session = Depends(get_db)):
+    """
+    Exchange a valid refresh token for a new access token + rotated refresh token.
+    The old refresh token is immediately revoked (rotation prevents replay attacks).
+    """
+    user_id, new_refresh = verify_and_rotate_refresh_token(body.refresh_token, db)
+    new_access = create_access_token(data={"sub": str(user_id)})
+    return {
+        "access_token": new_access,
+        "refresh_token": new_refresh,
+        "token_type": "bearer",
+    }
 
 
 @router.get("/me", response_model=UserResponse)
@@ -92,11 +116,12 @@ def update_me(
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
 def logout(
     request: Request,
-    _: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     token = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
     blacklist_token(token, db)
+    revoke_all_refresh_tokens(user.id, db)
     purge_expired_blacklist(db)
 
 
@@ -112,5 +137,3 @@ def change_password(
     user.hashed_password = hash_password(req.new_password)
     db.commit()
     return {"detail": "Password updated"}
-
-

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -69,7 +69,12 @@ class UserResponse(BaseModel):
 
 class Token(BaseModel):
     access_token: str
+    refresh_token: str
     token_type: str
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
 
 
 class UserUpdate(BaseModel):

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,4 +1,6 @@
+import hashlib
 import os
+import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -9,15 +11,19 @@ from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
 from app.database import get_db
+from app.models.refresh_token import RefreshToken
 from app.models.token_blacklist import TokenBlacklist
 from app.models.user import User
 
 SECRET_KEY = os.environ["JWT_SECRET"]
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 1440  # 24 hours
+ACCESS_TOKEN_EXPIRE_MINUTES = 15   # short-lived; silently refreshed via refresh token
+REFRESH_TOKEN_EXPIRE_DAYS = 30
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
 
+
+# ── password helpers ──────────────────────────────────────────────────────────
 
 def hash_password(password: str) -> str:
     return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
@@ -28,6 +34,8 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
         plain_password.encode("utf-8"), hashed_password.encode("utf-8")
     )
 
+
+# ── access token ──────────────────────────────────────────────────────────────
 
 def create_access_token(data: dict) -> str:
     to_encode = data.copy()
@@ -62,6 +70,80 @@ def purge_expired_blacklist(db: Session) -> None:
     ).delete(synchronize_session=False)
     db.commit()
 
+
+# ── refresh token ─────────────────────────────────────────────────────────────
+
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def create_refresh_token(user_id: int, db: Session) -> str:
+    """Generate a new refresh token, persist its hash, and return the raw value."""
+    raw = secrets.token_urlsafe(48)
+    expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    db.add(
+        RefreshToken(
+            user_id=user_id,
+            token_hash=_hash_token(raw),
+            expires_at=expires_at,
+        )
+    )
+    db.commit()
+    return raw
+
+
+def verify_and_rotate_refresh_token(raw: str, db: Session) -> tuple[int, str]:
+    """
+    Validate a refresh token, revoke it, and issue a replacement.
+
+    Returns ``(user_id, new_raw_refresh_token)``.
+    Raises HTTP 401 on any validation failure.
+    """
+    record = (
+        db.query(RefreshToken)
+        .filter(RefreshToken.token_hash == _hash_token(raw))
+        .first()
+    )
+
+    invalid = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid or expired refresh token",
+    )
+
+    if not record:
+        raise invalid
+    if record.revoked:
+        # Possible token reuse attack — revoke every token for this user.
+        db.query(RefreshToken).filter(RefreshToken.user_id == record.user_id).update(
+            {"revoked": True}
+        )
+        db.commit()
+        raise invalid
+
+    # SQLite stores naive datetimes; normalise before comparing.
+    expires_at = record.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    if expires_at < datetime.now(timezone.utc):
+        raise invalid
+
+    record.revoked = True
+    db.commit()
+
+    new_raw = create_refresh_token(record.user_id, db)
+    return record.user_id, new_raw
+
+
+def revoke_all_refresh_tokens(user_id: int, db: Session) -> None:
+    """Revoke every active refresh token for a user (called on logout)."""
+    db.query(RefreshToken).filter(
+        RefreshToken.user_id == user_id,
+        RefreshToken.revoked.is_(False),
+    ).update({"revoked": True})
+    db.commit()
+
+
+# ── current-user dependency ───────────────────────────────────────────────────
 
 def get_current_user(
     token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)

--- a/backend/tests/test_auth_refresh.py
+++ b/backend/tests/test_auth_refresh.py
@@ -1,0 +1,109 @@
+"""Tests for the JWT refresh-token mechanism."""
+import pytest
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _register_and_login(client, username="refreshuser", password="Refreshpass1"):
+    client.post(
+        "/api/auth/register",
+        json={"username": username, "email": f"{username}@example.com", "password": password},
+    )
+    res = client.post("/api/auth/login", json={"username": username, "password": password})
+    assert res.status_code == 200
+    return res.json()
+
+
+# ── login response shape ──────────────────────────────────────────────────────
+
+def test_login_returns_refresh_token(client):
+    data = _register_and_login(client)
+    assert "access_token" in data
+    assert "refresh_token" in data
+    assert data["token_type"] == "bearer"
+    assert len(data["refresh_token"]) > 20
+
+
+# ── /refresh endpoint ─────────────────────────────────────────────────────────
+
+def test_refresh_issues_new_access_token(client):
+    tokens = _register_and_login(client)
+    res = client.post("/api/auth/refresh", json={"refresh_token": tokens["refresh_token"]})
+    assert res.status_code == 200
+    new_tokens = res.json()
+    assert "access_token" in new_tokens
+    assert "refresh_token" in new_tokens
+    assert new_tokens["access_token"] != tokens["access_token"]
+
+
+def test_refresh_rotates_refresh_token(client):
+    tokens = _register_and_login(client)
+    res = client.post("/api/auth/refresh", json={"refresh_token": tokens["refresh_token"]})
+    assert res.status_code == 200
+    assert res.json()["refresh_token"] != tokens["refresh_token"]
+
+
+def test_refresh_new_access_token_is_valid(client):
+    tokens = _register_and_login(client)
+    refresh_res = client.post("/api/auth/refresh", json={"refresh_token": tokens["refresh_token"]})
+    new_access = refresh_res.json()["access_token"]
+    me_res = client.get("/api/auth/me", headers={"Authorization": f"Bearer {new_access}"})
+    assert me_res.status_code == 200
+
+
+def test_refresh_old_token_rejected_after_rotation(client):
+    tokens = _register_and_login(client)
+    old_refresh = tokens["refresh_token"]
+    client.post("/api/auth/refresh", json={"refresh_token": old_refresh})
+    # Replaying the old refresh token must be rejected.
+    res = client.post("/api/auth/refresh", json={"refresh_token": old_refresh})
+    assert res.status_code == 401
+
+
+def test_refresh_rejects_invalid_token(client):
+    _register_and_login(client)
+    res = client.post("/api/auth/refresh", json={"refresh_token": "not-a-real-token"})
+    assert res.status_code == 401
+
+
+def test_refresh_rejects_empty_token(client):
+    res = client.post("/api/auth/refresh", json={"refresh_token": ""})
+    assert res.status_code == 401
+
+
+# ── logout revokes refresh token ──────────────────────────────────────────────
+
+def test_logout_revokes_refresh_token(client):
+    tokens = _register_and_login(client)
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    logout_res = client.post("/api/auth/logout", headers=headers)
+    assert logout_res.status_code == 204
+
+    # Refresh token must no longer work after logout.
+    refresh_res = client.post("/api/auth/refresh", json={"refresh_token": tokens["refresh_token"]})
+    assert refresh_res.status_code == 401
+
+
+# ── replay-attack detection ───────────────────────────────────────────────────
+
+def test_token_reuse_revokes_all_tokens_for_user(client):
+    """
+    If a rotated (already-used) refresh token is presented again, the server
+    should revoke ALL refresh tokens for that user as a compromise response.
+    """
+    tokens = _register_and_login(client)
+    old_refresh = tokens["refresh_token"]
+
+    # First use — valid rotation.
+    res1 = client.post("/api/auth/refresh", json={"refresh_token": old_refresh})
+    assert res1.status_code == 200
+    new_refresh = res1.json()["refresh_token"]
+
+    # Replay the already-rotated token — triggers compromise detection.
+    res2 = client.post("/api/auth/refresh", json={"refresh_token": old_refresh})
+    assert res2.status_code == 401
+
+    # The freshly-issued token should also be invalidated now.
+    res3 = client.post("/api/auth/refresh", json={"refresh_token": new_refresh})
+    assert res3.status_code == 401

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -37,6 +37,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = async (uname: string, password: string) => {
     const res = await apiLogin({ username: uname, password });
     localStorage.setItem('token', res.data.access_token);
+    localStorage.setItem('refresh_token', res.data.refresh_token);
     localStorage.setItem('username', uname);
     setToken(res.data.access_token);
     setUsername(uname);
@@ -54,6 +55,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Proceed with local cleanup even if the server call fails
     } finally {
       localStorage.removeItem('token');
+      localStorage.removeItem('refresh_token');
       localStorage.removeItem('username');
       setToken(null);
       setUsername(null);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -23,6 +23,7 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
 });
 
+// ── request: attach stored access token ──────────────────────────────────────
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('token');
   if (token) {
@@ -31,45 +32,106 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+// ── silent-refresh state ──────────────────────────────────────────────────────
+let isRefreshing = false;
+let pendingQueue: Array<(accessToken: string) => void> = [];
+
+function drainQueue(newToken: string) {
+  pendingQueue.forEach((cb) => cb(newToken));
+  pendingQueue = [];
+}
+
+function clearAuthAndRedirect() {
+  localStorage.removeItem('token');
+  localStorage.removeItem('refresh_token');
+  localStorage.removeItem('username');
+  isRefreshing = false;
+  pendingQueue = [];
+  window.location.href = `${import.meta.env.BASE_URL ?? '/'}login`;
+}
+
+// ── response: silent token refresh on 401 ────────────────────────────────────
 api.interceptors.response.use(
   (res) => res,
-  (error) => {
-    const isLoginRequest = error.config?.url?.includes('/auth/login');
-    if (error.response?.status === 401 && !isLoginRequest) {
-      localStorage.removeItem('token');
-      window.location.href = `${import.meta.env.BASE_URL}login`;
+  async (error) => {
+    const originalRequest = error.config as typeof error.config & { _retry?: boolean };
+
+    // Don't attempt refresh for auth endpoints or already-retried requests.
+    const isAuthRequest =
+      originalRequest?.url?.includes('/auth/login') ||
+      originalRequest?.url?.includes('/auth/refresh') ||
+      originalRequest?.url?.includes('/auth/register');
+
+    if (error.response?.status !== 401 || isAuthRequest || originalRequest._retry) {
+      return Promise.reject(error);
     }
-    return Promise.reject(error);
-  }
+
+    const refreshToken = localStorage.getItem('refresh_token');
+    if (!refreshToken) {
+      clearAuthAndRedirect();
+      return Promise.reject(error);
+    }
+
+    // If a refresh is already in progress, queue this request.
+    if (isRefreshing) {
+      return new Promise<typeof error.config>((resolve) => {
+        pendingQueue.push((newToken: string) => {
+          originalRequest.headers.Authorization = `Bearer ${newToken}`;
+          resolve(api(originalRequest));
+        });
+      });
+    }
+
+    originalRequest._retry = true;
+    isRefreshing = true;
+
+    try {
+      // Use a plain axios call to avoid triggering this interceptor recursively.
+      const base = import.meta.env.VITE_API_BASE_URL || '/api';
+      const res = await axios.post<Token>(`${base}/auth/refresh`, {
+        refresh_token: refreshToken,
+      });
+
+      const { access_token, refresh_token: newRefresh } = res.data;
+      localStorage.setItem('token', access_token);
+      localStorage.setItem('refresh_token', newRefresh);
+
+      drainQueue(access_token);
+      originalRequest.headers.Authorization = `Bearer ${access_token}`;
+      return api(originalRequest);
+    } catch {
+      clearAuthAndRedirect();
+      return Promise.reject(error);
+    } finally {
+      isRefreshing = false;
+    }
+  },
 );
 
-// Auth
+// ── Auth ──────────────────────────────────────────────────────────────────────
 export const register = (data: { username: string; email: string; password: string }) =>
   api.post<User>('/auth/register', data);
 
 export const login = (data: { username: string; password: string }) =>
   api.post<Token>('/auth/login', data);
 
-export const logoutApi = () => api.post<void>('/auth/logout');
+export const logout = () => api.post<void>('/auth/logout');
 
-export const logout = () =>
-  api.post<{ detail: string }>('/auth/logout');
+export const refreshToken = (data: { refresh_token: string }) =>
+  api.post<Token>('/auth/refresh', data);
 
 export const getMe = () => api.get<User>('/auth/me');
 
 export const updateMe = (data: UserUpdate) => api.put<User>('/auth/me', data);
 
-export const changePassword = (data: ChangePasswordRequest) => api.post<{ detail: string }>(
-  '/auth/change-password',
-  data,
-);
+export const changePassword = (data: ChangePasswordRequest) =>
+  api.post<{ detail: string }>('/auth/change-password', data);
 
-// Words
+// ── Words ─────────────────────────────────────────────────────────────────────
 export const getWords = (params?: { category?: string; difficulty?: number }) =>
   api.get<Word[]>('/words', { params });
 
-export const getCategories = () =>
-  api.get<string[]>('/words/categories');
+export const getCategories = () => api.get<string[]>('/words/categories');
 
 export const getReviewWords = (limit = 10) =>
   api.get<ReviewWord[]>('/words/review', { params: { limit } });
@@ -77,24 +139,29 @@ export const getReviewWords = (limit = 10) =>
 export const submitReview = (wordId: number, knew: boolean) =>
   api.post(`/words/${wordId}/review`, { knew });
 
-// Quiz
-export const generateQuiz = (params: { category?: string; count?: number; quiz_type?: string; difficulty?: number; target_language?: string }) =>
-  api.post<Quiz>('/quiz/generate', params);
+// ── Quiz ──────────────────────────────────────────────────────────────────────
+export const generateQuiz = (params: {
+  category?: string;
+  count?: number;
+  quiz_type?: string;
+  difficulty?: number;
+  target_language?: string;
+}) => api.post<Quiz>('/quiz/generate', params);
 
-export const submitQuiz = (quizId: number, answers: { question_id: number; user_answer: string }[]) =>
-  api.post<QuizSubmitResult>(`/quiz/${quizId}/submit`, { answers });
+export const submitQuiz = (
+  quizId: number,
+  answers: { question_id: number; user_answer: string }[],
+) => api.post<QuizSubmitResult>(`/quiz/${quizId}/submit`, { answers });
 
-export const getQuizHistory = () =>
-  api.get<QuizResult[]>('/quiz/history');
+export const getQuizHistory = () => api.get<QuizResult[]>('/quiz/history');
 
-// Progress
-export const getProgressSummary = () =>
-  api.get<ProgressSummary>('/progress/summary');
+// ── Progress ──────────────────────────────────────────────────────────────────
+export const getProgressSummary = () => api.get<ProgressSummary>('/progress/summary');
 
 export const getProgressHistory = (days = 30) =>
   api.get<DailyProgress[]>('/progress/history', { params: { days } });
 
-// Oral practice (speaking)
+// ── Oral practice (speaking) ──────────────────────────────────────────────────
 export const submitOralPracticeAttempt = (data: {
   question_id: number;
   category: string;
@@ -105,21 +172,26 @@ export const submitOralPracticeAttempt = (data: {
 export const getOralPracticeHistory = (limit = 50) =>
   api.get<OralPracticeAttempt[]>('/oral-practice/history', { params: { limit } });
 
-// Writing evaluation
+// ── Writing evaluation ────────────────────────────────────────────────────────
 export const evaluateWriting = (data: WritingEvaluateRequest) =>
   api.post<WritingEvaluationOut>('/writing/evaluate', data);
 
 export const getWritingHistory = (limit = 20) =>
   api.get<WritingEvaluationOut[]>('/writing/history', { params: { limit } });
 
-// Image Quiz
-export const getImageCategories = () =>
-  api.get<string[]>('/image-quiz/categories');
+// ── Image Quiz ────────────────────────────────────────────────────────────────
+export const getImageCategories = () => api.get<string[]>('/image-quiz/categories');
 
-export const generateImageQuiz = (params: { category?: string; count?: number; difficulty?: number; mode?: string }) =>
-  api.post<ImageQuiz>('/image-quiz/generate', params);
+export const generateImageQuiz = (params: {
+  category?: string;
+  count?: number;
+  difficulty?: number;
+  mode?: string;
+}) => api.post<ImageQuiz>('/image-quiz/generate', params);
 
-export const submitImageQuiz = (quizId: number, answers: { question_id: number; user_answer: string }[]) =>
-  api.post<ImageQuizSubmitResult>(`/image-quiz/${quizId}/submit`, { answers });
+export const submitImageQuiz = (
+  quizId: number,
+  answers: { question_id: number; user_answer: string }[],
+) => api.post<ImageQuizSubmitResult>(`/image-quiz/${quizId}/submit`, { answers });
 
 export default api;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,6 +6,7 @@ export interface User {
 
 export interface Token {
   access_token: string;
+  refresh_token: string;
   token_type: string;
 }
 


### PR DESCRIPTION
## Changes
- Added `RefreshToken` database model to persist hashed refresh tokens with expiry and revocation state.
- Shortened access token lifetime from 24 hours to **15 minutes** (tokens now silently refreshed in the background).
- `POST /api/auth/login` now returns both `access_token` and `refresh_token`.
- New `POST /api/auth/refresh` endpoint: validates refresh token, rotates it (old token immediately revoked), and returns a new token pair.
- `POST /api/auth/logout` revokes all active refresh tokens for the user.
- Replay-attack guard: presenting an already-rotated refresh token triggers full revocation of all tokens for that user.
- Frontend Axios response interceptor: transparently retries any `401`-failing request after silently refreshing tokens; concurrent requests are queued until a single refresh completes.
- `useAuth.tsx` stores and clears `refresh_token` in `localStorage` on login/logout.
- Only the SHA-256 hash of each refresh token is stored in the database.

## Purpose
- Eliminate forced re-logins caused by short-lived access tokens with no renewal path.
- Keep user sessions alive for up to 30 days without requiring manual re-authentication.
- Prevent sudden unexpected logouts mid-session.
- Improve security by shortening access token validity to 15 minutes while maintaining UX continuity.

## Test Result
- 9 new backend tests added covering: login response shape, token rotation, new token validity, replay-attack detection, logout revocation, and rejection of invalid/empty tokens.
- Full backend test suite: **29/29 passed** ✅
- `git push` to `ZeyuXu/fix-api-query-validation` @ `01aef23` ✅

## Related Issue
#72 

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Docs
- [x] Test

## Checklist
- [x] Code builds locally
- [x] No new blocking errors
- [x] PR ready for review