### PR TITLE
fix(seed): register WritingEvaluation model for mapper initialization

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,8 @@ from app.models.progress import UserWordProgress
 from app.models.quiz import Quiz, QuizQuestion
 from app.models.oral_practice import OralPracticeAttempt
 from app.models.refresh_token import RefreshToken
+from app.models.token_blacklist import TokenBlacklist
+from app.models.writing_evaluation import WritingEvaluation
 
 __all__ = [
     "User",
@@ -13,4 +15,6 @@ __all__ = [
     "QuizQuestion",
     "OralPracticeAttempt",
     "RefreshToken",
+    "TokenBlacklist",
+    "WritingEvaluation",
 ]


### PR DESCRIPTION
## Changes
- Import `WritingEvaluation` and related models in `backend/app/models/__init__.py`
- Export newly added models in `__all__` to ensure mapper initialization can resolve relationships
- Verify local seeding flow works again on a fresh database

## Purpose
`seed.py` failed on fresh setup because SQLAlchemy could not resolve the `WritingEvaluation` relationship from `User`. This change ensures all related models are registered during ORM mapper initialization.

## Test Result
- [x] `python seed.py` runs successfully on a clean database
- [x] `python seed_images.py` runs successfully
- [x] Progress APIs no longer fail due to initialization/schema mismatch in local setup

## Related Issue
Fixes #162 

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Docs
- [ ] Test

## Checklist
- [x] Code builds locally
- [x] No new warnings/errors
- [x] PR ready for review