### PR TITLE
fix: reorder top navigation to match learning flow

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -84,15 +84,16 @@ export default function Layout() {
               <div className="hidden sm:flex items-center gap-1 rounded-full bg-slate-100/80 p-1">
                 <NavLink to="/">Dashboard</NavLink>
                 <NavLink to="/review">Review</NavLink>
+                <NavLink to="/quiz">Quiz</NavLink>
+                <NavLink to="/image-quiz">Picture Guess</NavLink>
                 <NavLink to="/listening" prominent note="Offline resources included">
                   Listening
                 </NavLink>
-                <NavLink to="/quiz">Quiz</NavLink>
-                <NavLink to="/campus-guide">Campus &amp; Changsha</NavLink>
-                <NavLink to="/image-quiz">Picture Guess</NavLink>
+                <NavLink to="/speaking">Speaking</NavLink>
+                <NavLink to="/oral-practice">Oral Practice</NavLink>
                 <NavLink to="/writing">Writing</NavLink>
                 <NavLink to="/progress">Progress</NavLink>
-                <NavLink to="/speaking">Speaking</NavLink>
+                <NavLink to="/campus-guide">Campus &amp; Changsha</NavLink>
               </div>
             </div>
             <div className="flex items-center space-x-4">
@@ -125,14 +126,15 @@ export default function Layout() {
           <NavLink to="/">Dashboard</NavLink>
           <NavLink to="/review">Review</NavLink>
           <NavLink to="/quiz">Quiz</NavLink>
-          <NavLink to="/campus-guide">Guides</NavLink>
           <NavLink to="/image-quiz">Picture</NavLink>
-          <NavLink to="/writing">Writing</NavLink>
-          <NavLink to="/progress">Progress</NavLink>
-          <NavLink to="/speaking">Speaking</NavLink>
           <NavLink to="/listening" prominent note="Offline resources included">
             Listening
           </NavLink>
+          <NavLink to="/speaking">Speaking</NavLink>
+          <NavLink to="/oral-practice">Oral</NavLink>
+          <NavLink to="/writing">Writing</NavLink>
+          <NavLink to="/progress">Progress</NavLink>
+          <NavLink to="/campus-guide">Guides</NavLink>
         </div>
       </nav>
 


### PR DESCRIPTION
## Summary
Closes #166

- Reorder top navigation items (desktop + mobile) to better match a typical daily study flow:
  - Review → Quiz (incl. Picture Guess) → Listening → Speaking / Oral Practice → Writing → Progress → Guides
- Keep external links at the end.

## Affected Files
- `frontend/src/components/Layout.tsx` — reordered `NavLink` items in desktop and mobile nav

## Test plan
- [ ] Open the app and verify the nav order on desktop width
- [ ] Resize to mobile width and verify the nav order in the mobile nav bar
- [ ] Run `npm run build` in `frontend`